### PR TITLE
Require layout bug

### DIFF
--- a/lib/mustache/sinatra.rb
+++ b/lib/mustache/sinatra.rb
@@ -51,11 +51,6 @@ class Mustache
           options = settings.send(:mustache).merge(options)
         end
 
-        # Find and cache the view class we want. This ensures the
-        # compiled template is cached, too - no looking up and
-        # compiling templates on each page load.
-        klass = mustache_class(template, options)
-
         # If they aren't explicitly disabling layouts, try to find
         # one.
         if options[:layout] != false
@@ -76,12 +71,18 @@ class Mustache
             layout = layout.new
           end
 
-          # Does the view subclass the layout? If so we'll use the
-          # view to render the layout so you can override layout
-          # methods in your view - tricky.
-          view_subclasses_layout = klass < layout.class if layout
         end
 
+        # Find and cache the view class we want. This ensures the
+        # compiled template is cached, too - no looking up and
+        # compiling templates on each page load.
+        klass = mustache_class(template, options)
+        
+        # Does the view subclass the layout? If so we'll use the
+        # view to render the layout so you can override layout
+        # methods in your view - tricky.
+        view_subclasses_layout = klass < layout.class if layout
+        
         # Create a new instance for playing with.
         instance = klass.new
 


### PR DESCRIPTION
In a Sinatra implementation of Mustache, I came across the following scenario: I had a view class in a subfolder (`views/foo/edit`) that worked when it subclassed `Mustache`, but failed when subclassing a Layout (`views/foo/layout`). Neither `< Views::Layout` nor `< Layout` worked. I realized that the `mustache` Sinatra helper method was attempting to require `Views::Edit` before requiring `Views::Layout`, which of course threw a `NameError`. Processing the layout first solves this problem.
