### PR TITLE
Terminate

### DIFF
--- a/lib/mustache/parser.rb
+++ b/lib/mustache/parser.rb
@@ -182,7 +182,7 @@ EOF
         # Couldn't find any otag, which means the rest is just static text.
         text = @scanner.rest
         # Mark as done.
-        @scanner.clear
+        @scanner.terminate
       end
 
       text.force_encoding(@encoding) if @encoding


### PR DESCRIPTION
The world's most trivial patch: replace StringScanner#clear with StringScanner#terminate to shut up a warning in Ruby 1.9.2
