### PR TITLE
Escape html method

### DIFF
--- a/lib/mustache/generator.rb
+++ b/lib/mustache/generator.rb
@@ -27,6 +27,15 @@ class Mustache
   #   $ mustache --compile test.mustache
   #   "Hi #{CGI.escapeHTML(ctx[:thing].to_s)}!\n"
   class Generator
+    # Customize the method used for escaping HTML content in Mustache tags.
+    def self.escape_html_method
+      @escape_html_method ||= "CGI.escapeHTML"
+    end
+
+    def self.escape_html_method=(method_name)
+      @escape_html_method = method_name
+    end
+
     # Options are unused for now but may become useful in the future.
     def initialize(options = {})
       @options = options
@@ -153,7 +162,7 @@ class Mustache
         v = ctx[#{name.to_sym.inspect}]
         v = Mustache::Template.new(v.call.to_s).render(ctx.dup) if v.is_a?(Proc)
         ctx.frame[ctx.key] = v if ctx.frame.is_a?(Hash)
-        CGI.escapeHTML(v.to_s)
+        #{self.class.escape_html_method}(v.to_s)
       compiled
     end
 

--- a/test/template_test.rb
+++ b/test/template_test.rb
@@ -17,4 +17,16 @@ class TemplateTest < Test::Unit::TestCase
   def test_token_with_source
     assert_equal [:multi, [:static, "bar"]], Mustache::Template.new("foo").tokens("bar")
   end
+
+  def test_compile_with_default_escape_html_method
+    assert_match "CGI.escapeHTML", Mustache::Template.new("{{foo}}").compile
+  end
+
+  def test_compile_with_custom_escape_html_method
+    old = Mustache::Generator.escape_html_method
+    Mustache::Generator.escape_html_method = "Foo.Bar"
+    assert_match "Foo.Bar", Mustache::Template.new("{{foo}}").compile
+  ensure
+    Mustache::Generator.escape_html_method = old
+  end
 end


### PR DESCRIPTION
I'd like to use EscapeUtils without depending on monkeypatching `CGI.escapeHTML`.
