### PR TITLE
Render with symbol

### DIFF
--- a/lib/mustache.rb
+++ b/lib/mustache.rb
@@ -362,6 +362,9 @@ class Mustache
     if data.is_a? Hash
       ctx = data
       tpl = templateify(template)
+    elsif data.is_a? Symbol
+      self.class.template_name = data
+      tpl = templateify(template)
     else
       tpl = templateify(data)
     end

--- a/test/mustache_test.rb
+++ b/test/mustache_test.rb
@@ -225,6 +225,24 @@ data
                                                      :deploy_to => '/var/www/example.com' )
   end
 
+  def test_render_from_symbol
+    expected = <<-data
+<VirtualHost *>
+  ServerName example.com
+  DocumentRoot /var/www/example.com
+  RailsEnv production
+</VirtualHost>
+data
+    old_path, Mustache.template_path = Mustache.template_path, File.dirname(__FILE__) + "/fixtures"
+    old_extension, Mustache.template_extension = Mustache.template_extension, "conf"
+
+    assert_equal expected, Mustache.render(:passenger, :stage => 'production',
+                                                       :server => 'example.com',
+                                                       :deploy_to => '/var/www/example.com' )
+
+    Mustache.template_path, Mustache.template_extension = old_path, old_extension
+  end
+
   def test_doesnt_execute_what_it_doesnt_need_to
     instance = Mustache.new
     instance[:show] = false


### PR DESCRIPTION
allow render to take a symbol identifying template by name

this means i can do the following:

```
Mustache.render(:foo, {:bar => :baz})
```

to get `foo.mustache` to render with the above data
