### PR TITLE
Compile dot notation and implicit iterators

### DIFF
--- a/lib/mustache/context.rb
+++ b/lib/mustache/context.rb
@@ -96,20 +96,6 @@ class Mustache
     def fetch(name, default = :__raise)
       @key = name
 
-      if name == :'.'
-        # implicit iterators - {{.}}
-        name = :to_s
-      elsif name.to_s.include? '.'
-        # dot notation - {{person.name}}
-        parts = name.to_s.split('.')
-
-        parts.each do |part|
-          push fetch(part.to_sym)
-        end
-
-        return @stack.shift(parts.size).first
-      end
-
       @stack.each do |frame|
         # Prevent infinite recursion.
         next if frame == self

--- a/lib/mustache/parser.rb
+++ b/lib/mustache/parser.rb
@@ -174,7 +174,18 @@ EOF
         type = "}" if type == "{"
         @result << [:mustache, :utag, content]
       else
-        @result << [:mustache, :etag, content]
+        parts = content.to_s.split(".").reverse
+
+        if parts.size == 0
+          # implicit iterators - {{.}}
+          @result << [:mustache, :etag, "to_s"]
+        else
+          # dot notation - {{person.name}}
+          etag = [:mustache, :etag, parts.shift]
+          @result << parts.inject(etag) { |section, key|
+            [:mustache, :section, key, section, content]
+          }
+        end
       end
 
       # Skip whitespace and any balancing sigils after the content


### PR DESCRIPTION
Besides speed, this makes the AST simpler to interpret at runtime.
