### PR TITLE
Method section

### DIFF
--- a/lib/mustache/context.rb
+++ b/lib/mustache/context.rb
@@ -112,7 +112,7 @@ class Mustache
         elsif !hash && frame.respond_to?(name)
           @frame = nil
           meth = frame.method(name)
-          if meth.arity.abs==1
+          if meth.arity == 1
             return meth.to_proc
           else
             return meth[]

--- a/test/mustache_test.rb
+++ b/test/mustache_test.rb
@@ -385,22 +385,13 @@ data
 
   def test_sections_which_refer_to_unary_method_call_them_as_proc
     kls = Class.new(Mustache) {
-      def basic(arg)
-        "(#{arg})"
-      end
-      def default_arg(arg='default')
+      def unary_method(arg)
         "(#{arg})"
       end
     }
-
-    str = kls.render("{{#basic}}test{{/basic}}")
-    assert_equal str, "(test)"
     
-    str = kls.render("{{default_arg}}")
-    assert_equal str, "(default)"
-    
-    str = kls.render("{{#default_arg}}test{{/default_arg}}")
-    assert_equal str, "(test)"
+    str = kls.render("{{#unary_method}}test{{/unary_method}}")
+    assert_equal "(test)", str
   end
 
   def test_lots_of_staches


### PR DESCRIPTION
Now works with 1.8. 
Problem was the kind of weird way 1.8 manages proc attributes.
'proc {  } ' was interpreted as 'proc { |*| }' instead of 'proc { || }'.

So I just remove "-1 arity" methods management.
