### PR TITLE
Context#find

### DIFF
--- a/lib/mustache/context.rb
+++ b/lib/mustache/context.rb
@@ -12,8 +12,6 @@ class Mustache
   # A Context represents the context which a Mustache template is
   # executed within. All Mustache tags reference keys in the Context.
   class Context
-    attr_accessor :frame, :key
-
     # Expect to be passed an instance of `Mustache`.
     def initialize(mustache)
       @stack = [mustache]
@@ -94,33 +92,30 @@ class Mustache
     # If no second parameter is passed (or raise_on_context_miss is
     # set to true), will raise a ContextMiss exception on miss.
     def fetch(name, default = :__raise)
-      @key = name
+      find(name, default)[1]
+    end
 
+    def find(name, default = nil)
       @stack.each do |frame|
         # Prevent infinite recursion.
         next if frame == self
-        @frame = frame
 
         # Is this frame a hash?
         hash = frame.respond_to?(:has_key?)
 
         if hash && frame.has_key?(name)
-          return frame[name]
+          return frame, frame[name]
         elsif hash && frame.has_key?(name.to_s)
-          @key = name.to_s
-          return frame[name.to_s]
+          return frame, frame[name.to_s]
         elsif !hash && frame.respond_to?(name)
-          @frame = nil
-          return frame.__send__(name)
+          return frame, frame.__send__(name)
         end
       end
-
-      @frame = @key = nil
 
       if default == :__raise || mustache_in_stack.raise_on_context_miss?
         raise ContextMiss.new("Can't find #{name} in #{@stack.inspect}")
       else
-        default
+        return nil, default
       end
     end
   end

--- a/lib/mustache/generator.rb
+++ b/lib/mustache/generator.rb
@@ -140,9 +140,10 @@ class Mustache
     # An unescaped tag.
     def on_utag(name)
       ev(<<-compiled)
-        v = ctx[#{name.to_sym.inspect}]
+        k = #{name.to_sym.inspect}
+        f, v = ctx.find(k)
         v = Mustache::Template.new(v.call.to_s).render(ctx.dup) if v.is_a?(Proc)
-        ctx.frame[ctx.key] = v if ctx.frame.is_a?(Hash)
+        f[k] = v if f.is_a?(Hash)
         v.to_s
       compiled
     end
@@ -150,9 +151,10 @@ class Mustache
     # An escaped tag.
     def on_etag(name)
       ev(<<-compiled)
-        v = ctx[#{name.to_sym.inspect}]
+        k = #{name.to_sym.inspect}
+        f, v = ctx.find(k)
         v = Mustache::Template.new(v.call.to_s).render(ctx.dup) if v.is_a?(Proc)
-        ctx.frame[ctx.key] = v if ctx.frame.is_a?(Hash)
+        f[k] = v if f.is_a?(Hash)
         ctx.escapeHTML(v.to_s)
       compiled
     end


### PR DESCRIPTION
**Don't actually pull this yet, idea needs review**

I don't really like how `Context` tracks this weird `@frame` and `@key` state when you call `#fetch`. I wasn't sure why, but it seems to only be used internal for caching. If we need access to the frame where we found the key, why can't we just return it along with the value?

I wasn't sure if `Context#fetch` was public api or not so I added another method `#find`. Not sure if this is a good name or we really need another method.

Looking at this change https://github.com/defunkt/mustache/pull/81/files#L0R129 motivated me to clean it up. Iterating, setting strange ivars, and then using try/catch for flow control is really unclear.

If its a good idea, I'll rebase it on top of pvandes changes.
