### PR TITLE
Allow context objects that extends Hash

### DIFF
--- a/lib/mustache/context.rb
+++ b/lib/mustache/context.rb
@@ -127,7 +127,7 @@ class Mustache
         obj[key]
       elsif hash && obj.has_key?(key.to_s)
         obj[key.to_s]
-      elsif !hash && obj.respond_to?(key)
+      elsif obj.respond_to?(key)
         meth = obj.method(key) rescue proc { obj.send(key) }
         if meth.arity == 1
           meth.to_proc


### PR DESCRIPTION
For example, I came to this integrating mustache in toto, where the Article class extends Hash. (https://github.com/cloudhead/toto/blob/master/lib/toto.rb#L221)
<code>Context#find</code> couldn't find Article methods.

I think it could be a more common use case, but maybe there's a particular reason for the <code>!hash</code> condition?
