### PR TITLE
Let's write custom tag generators

### DIFF
--- a/test/fixtures/generator_extensions.rb
+++ b/test/fixtures/generator_extensions.rb
@@ -1,0 +1,29 @@
+$LOAD_PATH.unshift File.dirname(__FILE__) + '/../lib'
+require 'mustache'
+
+class Mustache
+  class Generator
+    def i18n( lang, key )
+      @i18n ||= {
+        'en' => {
+          'name'          => '> Name',
+          'title'         => 'Title',
+          'in_my_country_link' => '<a href="/uk">In my country</a>'
+        },
+
+        'fr' => {
+          'name'          => '> Nom',
+          'title'         => 'Titre',
+          'in_my_country_link' => '<a href="/france">Dans mon pays</a>'
+        }
+      }
+
+      @i18n[ lang ][ key ]
+    end
+
+    def date
+      # Time.now
+      "2011-07-22 13:40:47 +0200"
+    end
+  end
+end

--- a/test/generator_extensions_test.rb
+++ b/test/generator_extensions_test.rb
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+
+$LOAD_PATH.unshift File.dirname(__FILE__)
+require 'helper'
+
+class GeneratorExtensionsTest < Test::Unit::TestCase
+  def test_extension_without_args
+    klass = Class.new(Mustache)
+    klass.template = "It is now : {{_date}}"
+    assert_equal "It is now : 2011-07-22 13:40:47 +0200", klass.render
+  end
+
+  def test_extension_with_args_and_escaped
+    klass = Class.new(Mustache)
+    klass.template = "{{_i18n.fr.name}}: The Doctor"
+    assert_equal "&gt; Nom: The Doctor", klass.render
+  end
+  
+  def test_extension_with_args_and_not_escaped
+    klass = Class.new(Mustache)
+    klass.template = "Pays: {{{_i18n.fr.in_my_country_link}}}"
+    assert_equal 'Pays: <a href="/france">Dans mon pays</a>', klass.render
+  end
+end


### PR DESCRIPTION
Hello,

I know mustache is supposed to be logicless, but I found it quite useful to be able to extend mustache with custom tags.

With this commit, we can declare new methods in Mustache::Generator ([example](https://github.com/oelmekki/mustache/blob/master/test/fixtures/generator_extensions.rb)) and then call them by prefixing with "_".

For example, I used that on rails, to access i18n, mapping what twitter did in mustache.js : {{_i.whatever.i18n.key}} .

It makes it simple to extend :

<pre>
class Mustache
  class Generator
    def i( *args )
      I18n.t( args.join( '.' ) )
    end
  end
end
</pre>
