### PR TITLE
Fix Context#find for Hash-like objects

### DIFF
--- a/lib/mustache/context.rb
+++ b/lib/mustache/context.rb
@@ -127,7 +127,7 @@ class Mustache
         obj[key]
       elsif hash && obj.has_key?(key.to_s)
         obj[key.to_s]
-      elsif !hash && obj.respond_to?(key)
+      elsif !obj.instance_of?(Hash) && obj.respond_to?(key)
         meth = obj.method(key) rescue proc { obj.send(key) }
         if meth.arity == 1
           meth.to_proc


### PR DESCRIPTION
This removes the exclusion of `Hash`-like objects from method execution through `Context#find`.

I encountered this problem while trying to get the `size` of a object inheriting from `Hash`.

I usually would not check for `Hash` at all but this would clash with use cases like [`test_id_with_nested_context`](https://github.com/defunkt/mustache/blob/master/test/mustache_test.rb#L495-508) where you wouldn't be able to access the `:id` key because of `Object#id`.
A possible solution for that problem would be a special `Hash` subclass for the Mustache contexts. Any thoughts on that?
