### PR TITLE
Fix for Ruby 1.9.3-rc1

### DIFF
--- a/bin/mustache
+++ b/bin/mustache
@@ -73,7 +73,7 @@ class Mustache
         yaml = $2.strip
         template = doc.sub($1, '')
 
-        YAML.each_document(yaml) do |data|
+        YAML.load_stream(yaml).each do |data|
           puts Mustache.render(template, data)
         end
       else


### PR DESCRIPTION
The executable was dying on me in Ruby 1.9.3-rc1, looks like an older method in the YAML module was being used. This was causing a `undefined method 'each_document' for Psych:Module (NoMethodError)`

I didn't find any tests for the executable, but running this at a bash prompt in the root of the project should verify it still works with multiple documents.

```
cat <<data | ./bin/mustache - ./examples/simple.mustache                                                                         

---
name: Awesome
value: 200
in_ca: true
taxed_value: 20

---
name: Awesome2
value: 400
in_ca: false

---
data
```
