### PR TITLE
Avoid raising ContextMiss when testing for key presence.

### DIFF
--- a/lib/mustache/context.rb
+++ b/lib/mustache/context.rb
@@ -80,7 +80,7 @@ class Mustache
     # Do we know about a particular key? In other words, will calling
     # `context[key]` give us a result that was set. Basically.
     def has_key?(key)
-      !!fetch(key)
+      !!fetch(key, false)
     rescue ContextMiss
       false
     end


### PR DESCRIPTION
Raising ContextMiss can be expensive.  The error message includes `@stack.inspect`, which depending on the size and content of the stack can be very costly to generate.  Defaulting to false for has_key? context misses retains the same behaviour without incurring this cost penalty.
