### PR TITLE
Support allowed liberal tag names in classes

### DIFF
--- a/lib/mustache/context.rb
+++ b/lib/mustache/context.rb
@@ -122,6 +122,11 @@ class Mustache
       hash = obj.respond_to?(:to_hash)
 
       if !hash
+        # If a class, we need to find tags (methods) per Parser::ALLOWED_CONTENT.
+        if key.to_s.include?('-')
+          key = key.to_s.gsub('-', '_')
+        end
+
         if obj.respond_to?(key)
           meth = obj.method(key) rescue proc { obj.send(key) }
           if meth.arity == 1

--- a/test/fixtures/liberal.mustache
+++ b/test/fixtures/liberal.mustache
@@ -1,0 +1,1 @@
+{{first-name}} {{middle_name!}} {{lastName?}}

--- a/test/fixtures/liberal.rb
+++ b/test/fixtures/liberal.rb
@@ -1,0 +1,22 @@
+$LOAD_PATH.unshift File.dirname(__FILE__) + '/../lib'
+require 'mustache'
+
+class Liberal < Mustache
+  self.path = File.dirname(__FILE__)
+
+  def first_name
+    "kevin"
+  end
+
+  def middle_name!
+    'j'
+  end
+
+  def lastName?
+    'sheurs'
+  end
+end
+
+if $0 == __FILE__
+  puts Liberal.to_html
+end

--- a/test/mustache_test.rb
+++ b/test/mustache_test.rb
@@ -454,6 +454,12 @@ data
     assert_equal "chris j strath", Mustache.render(template, hash)
   end
 
+  def test_liberal_tag_names_in_class
+    assert_equal <<-end_liberal, Liberal.render
+kevin j sheurs
+end_liberal
+  end
+
   def test_nested_sections_same_names
     template = <<template
 {{#items}}


### PR DESCRIPTION
Currently liberal tag names are only fully supported in hashes. Classes only support "?" and "!".

This pull request adds support for all Parser::ALLOWED_CONTENT to ruby classes except for "/", which is reserved for partials.
- [x] Rebase
- [x] Squash commits
