### PR TITLE
Fix Mustache#const_get! behavior

### DIFF
--- a/test/autoloading_test.rb
+++ b/test/autoloading_test.rb
@@ -53,4 +53,8 @@ end_render
   def test_bad_constant_name
     assert_equal Mustache, Mustache.view_class(404)
   end
+
+  def test_const_get!
+    assert_equal nil, Mustache.const_get!('TestViews::TestViews')
+  end
 end


### PR DESCRIPTION
By default, each call to `Module#const_get` will fall back on constants in `Object`.

``` ruby
require 'mustache' # v0.99.4
Mustache.const_get!('Mustache::Mustache::Mustache::Mustache')
# => Mustache
```

Thanks to an API change, the incantations to avoid this behavior changed in Ruby 1.9. My patch is based on Rails 3.2.1's implementation of [`String#constantize`](https://github.com/rails/rails/blob/v3.2.1/activesupport/lib/active_support/inflector/methods.rb#L192-L233).

This was an issue in my project because we have a Mustache view which shares a name with a top-level module. `Mustache#view_class`, thinking it found a view, would never attempt to load my view's implementation.
