### PR TITLE
Allow Rakefile to run with newer versions of Rake.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
 require 'rake/testtask'
-require 'rake/rdoctask'
+require 'rdoc/task'
 
 #
 # Helpers


### PR DESCRIPTION
Previously `rake` would show a deprecation warning re: rake/rdoctask and
then croak.
