### PR TITLE
Refactor to allow for easier extension of Parser

### DIFF
--- a/lib/mustache/parser.rb
+++ b/lib/mustache/parser.rb
@@ -44,6 +44,34 @@ EOF
       end
     end
 
+    # The sigil types which are valid after an opening `{{`
+    VALID_TYPES = [ '#', '^', '/', '=', '!', '<', '>', '&', '{' ]
+
+    def self.valid_types
+      @valid_types ||= Regexp.new(VALID_TYPES.map { |t| Regexp.escape(t) }.join('|') )
+    end
+
+    # Add a supported sigil type (with optional aliases) to the Parser.
+    #
+    # Requires a block, which will be sent the following parameters:
+    #
+    # * content - The raw content of the tag
+    # * fetch- A mustache context fetch expression for the content
+    # * padding - Indentation whitespace from the currently-parsed line
+    # * pre_match_position - Location of the scanner before a match was made
+    #
+    # The provided block will be evaluated against the current instance of
+    # Parser, and may append to the Parser's @result as needed.
+    def self.add_type(*types, &block)
+      types = types.map(&:to_s)
+      type, *aliases = types
+      method_name = "scan_tag_#{type}".to_sym
+      define_method(method_name, &block)
+      aliases.each { |a| alias_method "scan_tag_#{a}", method_name }
+      types.each { |t| VALID_TYPES << t unless VALID_TYPES.include?(t) }
+      @valid_types = nil
+    end
+
     # After these types of tags, all whitespace until the end of the line will
     # be skipped if they are the first (and only) non-whitespace content on
     # the line.
@@ -124,7 +152,7 @@ EOF
       # Since {{= rewrites ctag, we store the ctag which should be used
       # when parsing this specific tag.
       current_ctag = self.ctag
-      type = @scanner.scan(/#|\^|\/|=|!|<|>|&|\{/)
+      type = @scanner.scan(self.class.valid_types)
       @scanner.skip(/\s*/)
 
       # ANY_CONTENT tags allow any character inside of them, while
@@ -143,41 +171,16 @@ EOF
       prev = @result
 
       # Based on the sigil, do what needs to be done.
-      case type
-      when '#'
-        block = [:multi]
-        @result << [:mustache, :section, fetch, offset, block]
-        @sections << [content, position, @result]
-        @result = block
-      when '^'
-        block = [:multi]
-        @result << [:mustache, :inverted_section, fetch, offset, block]
-        @sections << [content, position, @result]
-        @result = block
-      when '/'
-        section, pos, result = @sections.pop
-        raw = @scanner.pre_match[pos[3]...pre_match_position] + padding
-        (@result = result).last << raw << [self.otag, self.ctag]
-
-        if section.nil?
-          error "Closing unopened #{content.inspect}"
-        elsif section != content
-          error "Unclosed section #{section.inspect}", pos
-        end
-      when '!'
-        # ignore comments
-      when '='
-        self.otag, self.ctag = content.split(' ', 2)
-      when '>', '<'
-        @result << [:mustache, :partial, content, offset, padding]
-      when '{', '&'
-        # The closing } in unescaped tags is just a hack for
-        # aesthetics.
-        type = "}" if type == "{"
-        @result << [:mustache, :utag, fetch, offset]
+      if type
+        # Method#call proves much faster than using send
+        method("scan_tag_#{type}").
+          call(content, fetch, padding, pre_match_position)
       else
         @result << [:mustache, :etag, fetch, offset]
       end
+      # The closing } in unescaped tags is just a hack for
+      # aesthetics.
+      type = "}" if type == "{"
 
       # Skip whitespace and any balancing sigils after the content
       # inside this tag.
@@ -263,5 +266,57 @@ EOF
     def error(message, pos = position)
       raise SyntaxError.new(message, pos)
     end
+
+    # These methods are called in `scan_tags`. Because they contain nonstandard
+    # characters in their method names, they are defined using define_method.
+
+    define_method 'scan_tag_#' do |content, fetch, padding, pre_match_position|
+      block = [:multi]
+      @result << [:mustache, :section, fetch, offset, block]
+      @sections << [content, position, @result]
+      @result = block
+    end
+
+    define_method 'scan_tag_^' do |content, fetch, padding, pre_match_position|
+      block = [:multi]
+      @result << [:mustache, :inverted_section, fetch, offset, block]
+      @sections << [content, position, @result]
+      @result = block
+    end
+
+    define_method 'scan_tag_/' do |content, fetch, padding, pre_match_position|
+      section, pos, result = @sections.pop
+      raw = @scanner.pre_match[pos[3]...pre_match_position] + padding
+      (@result = result).last << raw << [self.otag, self.ctag]
+
+      if section.nil?
+        error "Closing unopened #{content.inspect}"
+      elsif section != content
+        error "Unclosed section #{section.inspect}", pos
+      end
+    end
+
+    define_method 'scan_tag_!' do |content, fetch, padding, pre_match_position|
+    end
+
+    define_method 'scan_tag_=' do |content, fetch, padding, pre_match_position|
+      self.otag, self.ctag = content.split(' ', 2)
+    end
+
+    define_method 'scan_tag_>' do |content, fetch, padding, pre_match_position|
+      @result << [:mustache, :partial, content, offset, padding]
+    end
+    alias_method :'scan_tag_<', :'scan_tag_>'
+
+    define_method 'scan_tag_>' do |content, fetch, padding, pre_match_position|
+      @result << [:mustache, :partial, content, offset, padding]
+    end
+    alias_method :'scan_tag_<', :'scan_tag_>'
+
+    define_method 'scan_tag_{' do |content, fetch, padding, pre_match_position|
+      @result << [:mustache, :utag, fetch, offset]
+    end
+    alias_method :'scan_tag_&', :'scan_tag_{'
+
   end
 end

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -2,6 +2,21 @@ $LOAD_PATH.unshift File.dirname(__FILE__)
 require 'helper'
 
 class ParserTest < Test::Unit::TestCase
+
+  def test_parser_extension
+    parser = Mustache::Parser.new
+    parser.instance_variable_set :@result, 'zomg'
+    Mustache::Parser.add_type(:'@', :'$') do |*args|
+      [:mustache, :at_sign, @result, *args]
+    end
+    assert_match Mustache::Parser.valid_types, '@'
+    assert_match Mustache::Parser.valid_types, '$'
+    assert_equal [:mustache, :at_sign, 'zomg', 1, 2, 3],
+                 parser.send('scan_tag_@', 1, 2, 3)
+    assert_equal [:mustache, :at_sign, 'zomg', 1, 2, 3],
+                 parser.send('scan_tag_$', 1, 2, 3)
+  end
+
   def test_parser
     lexer = Mustache::Parser.new
     tokens = lexer.compile(<<-EOF)


### PR DESCRIPTION
Mustache::Parser#scan_tags is a pretty hefty method. Right in the middle
of this method, we have a case statement that branches based on the
sigil of the parsed tag. By extracting these cases to methods, we can
instead dispatch via `Method#call`, which eliminates the branching and
also allow for extension of the Parser to support custom sigils. This is
roughly in line with what the Generator already supports, via definition
of `on_*` methods. There is a small performance increase due to this
change, as well, on my test machine with 1.9.3p392.
