### PR TITLE
Support i18n in templates. (no translate_only option)

### DIFF
--- a/lib/mustache.rb
+++ b/lib/mustache.rb
@@ -58,6 +58,24 @@ require 'mustache/settings'
 #   view[:person] = 'Mom'
 #   view.render # => Hi, mom!
 #
+# * i18n_namespace
+#
+# The `i18n_namespace` setting determines the namespace Mustache uses when
+# translating `{{% }}` and `{{$ }}` tags. By default this is "mustache".
+# Given the locale file:
+#
+#   en:
+#     mustache:
+#       greeting: 'Hello {{planet}}'
+#
+#   >> Mustache.render("{{%greeting}}", :planet => "World!")
+#   => "Hello World!"
+#
+# * locale
+#
+# The locale used when translating. By default this is the current value of
+# `I18n.locale`.
+#
 # * view_namespace
 #
 # To make life easy on those developing Mustache plugins for web frameworks or
@@ -191,6 +209,12 @@ class Mustache
     CGI.escapeHTML(str)
   end
 
+  # Override this to provide custom translation.
+  #
+  # Returns a String
+  def translate(key)
+    I18n.translate([i18n_namespace, key].compact.join('.'), :locale => locale)
+  end
 
   #
   # Private API

--- a/lib/mustache/context.rb
+++ b/lib/mustache/context.rb
@@ -34,6 +34,13 @@ class Mustache
       result = mustache.render(part, self)
     end
 
+    # Delegate translation duties to the Mustache in this Context's stack.
+    #
+    # Returns a String.
+    def translate(key)
+      mustache_in_stack.translate(key)
+    end
+
     # Find the first Mustache in the stack. If we're being rendered
     # inside a Mustache object as a context, we'll use that one.
     def mustache_in_stack

--- a/lib/mustache/parser.rb
+++ b/lib/mustache/parser.rb
@@ -62,7 +62,7 @@ EOF
     # Accepts an options hash which does nothing but may be used in
     # the future.
     def initialize(options = {})
-      @options = {}
+      @options = options
     end
 
     # The opening tag delimiter. This may be changed at runtime.
@@ -124,7 +124,7 @@ EOF
       # Since {{= rewrites ctag, we store the ctag which should be used
       # when parsing this specific tag.
       current_ctag = self.ctag
-      type = @scanner.scan(/#|\^|\/|=|!|<|>|&|\{/)
+      type = @scanner.scan(/#|\^|\/|=|!|<|>|&|\{|%|\$/)
       @scanner.skip(/\s*/)
 
       # ANY_CONTENT tags allow any character inside of them, while
@@ -170,6 +170,10 @@ EOF
         self.otag, self.ctag = content.split(' ', 2)
       when '>', '<'
         @result << [:mustache, :partial, content, offset, padding]
+      when '$'
+        @result << [:mustache, :ui18n, content]
+      when '%'
+        @result << [:mustache, :ei18n, content]
       when '{', '&'
         # The closing } in unescaped tags is just a hack for
         # aesthetics.

--- a/lib/mustache/settings.rb
+++ b/lib/mustache/settings.rb
@@ -162,6 +162,49 @@ class Mustache
     @template = templateify(template)
   end
 
+  #
+  # Translation
+  #
+
+  # I18n translations should be namespaced. The default is "mustache".
+  # This is because these translations may include Mustache utags and etags,
+  # which will at best, not be understood by I18n, and at worst, conflict with
+  # older versions of I18n's use of {{}}. If you just don't care, and feel like
+  # getting wild and crazy, set this value to nil, which will remove the default
+  # namespace.
+
+  def self.i18n_namespace
+    @i18n_namespace ||= 'mustache'
+  end
+
+  def self.i18n_namespace=(key)
+    @i18n_namespace = key
+  end
+
+  def i18n_namespace
+    @i18n_namespace || self.class.i18n_namespace
+  end
+
+  attr_writer :i18n_namespace
+
+  # The locale for translation will by default be the current I18n locale. We
+  # don't want to memoize this at the class level, because it's likely to be
+  # assumed that a change to I18n.locale would be reflected here if one were not
+  # explicitly configured. Also, threads are a thing.
+
+  def self.locale
+    @locale || I18n.locale
+  end
+
+  def self.locale=(locale)
+    @locale = locale
+  end
+
+  def locale
+    @locale ||= self.class.locale
+  end
+
+  attr_writer :locale
 
   #
   # Raise on context miss

--- a/lib/mustache/template.rb
+++ b/lib/mustache/template.rb
@@ -17,8 +17,7 @@ class Mustache
   class Template
     attr_reader :source
 
-    # Expects a Mustache template as a string along with a template
-    # path, which it uses to find partials.
+    # Expects a Mustache template as a String.
     def initialize(source)
       @source = source
     end
@@ -52,7 +51,12 @@ class Mustache
 
     # Returns an array of tokens for a given template.
     def tokens(src = @source)
-      Parser.new.compile(src)
+      tokenizer.compile(src)
+    end
+
+    # Returns a Parser for the template
+    def tokenizer
+      @tokenizer ||= Parser.new
     end
   end
 end

--- a/test/fixtures/translation.mustache
+++ b/test/fixtures/translation.mustache
@@ -1,0 +1,3 @@
+<h1>{{%title}}</h1>
+{{$body}}
+<p>{{exclamation}}</p>

--- a/test/fixtures/translation.rb
+++ b/test/fixtures/translation.rb
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+$LOAD_PATH.unshift File.dirname(__FILE__) + '/../lib'
+require 'i18n'
+require 'mustache'
+
+I18n.backend.store_translations(
+  :en,
+  :mustache => {
+    :title => 'Bear > Shark',
+    :body => '<p>Unless the shark has {{item}}.</p>'
+  },
+  :mustache_alternate => {
+    :title => 'Bear > Smaller Bear',
+    :body => '<p>Duh.</p>'
+  }
+)
+
+I18n.backend.store_translations(
+  :es,
+  :mustache => {
+    :title => 'Oso > Tiburón',
+    :body => '<p>A menos que el tiburón tiene {{item}}.</p>'
+  }
+)
+
+class Translation < Mustache
+  self.path = File.dirname(__FILE__)
+
+  def item
+    'laser beams'
+  end
+
+  def exclamation
+    "PEW PEW!"
+  end
+
+end
+
+if $0 == __FILE__
+  puts Translation.to_html
+end

--- a/test/mustache_test.rb
+++ b/test/mustache_test.rb
@@ -224,6 +224,45 @@ end_section
     assert_equal '<h1>Bear > Shark</h1>', view.render
   end
 
+  def test_translation
+    assert_equal <<end_template, Translation.render
+<h1>Bear &gt; Shark</h1>
+<p>Unless the shark has laser beams.</p>
+<p>PEW PEW!</p>
+end_template
+  end
+
+  def test_translation_locale_change
+    view = Translation.new
+    assert_equal <<end_template, view.render
+<h1>Bear &gt; Shark</h1>
+<p>Unless the shark has laser beams.</p>
+<p>PEW PEW!</p>
+end_template
+    view.locale = :es
+    view[:item] = "rayos láser"
+    assert_equal <<end_template, view.render
+<h1>Oso &gt; Tiburón</h1>
+<p>A menos que el tiburón tiene rayos láser.</p>
+<p>PEW PEW!</p>
+end_template
+  end
+
+  def test_translation_namespace_change
+    view = Translation.new
+    assert_equal <<end_template, view.render
+<h1>Bear &gt; Shark</h1>
+<p>Unless the shark has laser beams.</p>
+<p>PEW PEW!</p>
+end_template
+    view.i18n_namespace = 'mustache_alternate'
+    assert_equal <<end_template, view.render
+<h1>Bear &gt; Smaller Bear</h1>
+<p>Duh.</p>
+<p>PEW PEW!</p>
+end_template
+  end
+
   def test_classify
     assert_equal 'TemplatePartial', Mustache.classify('template_partial')
     assert_equal 'Admin::TemplatePartial', Mustache.classify('admin/template_partial')
@@ -285,7 +324,7 @@ data
     assert_equal expected, Mustache.render(:passenger, :stage => 'production',
                                                        :server => 'example.com',
                                                        :deploy_to => '/var/www/example.com' )
-
+  ensure
     Mustache.template_path, Mustache.template_extension = old_path, old_extension
   end
 


### PR DESCRIPTION
(This is an alternative to #150 that is simpler, by dropping an option supported by that PR)
- To HTML-escape an i18n string: {{% some.key.name }}
- To return an i18n string unmodified: {{$ some.key.name }}

i18n keys are loaded from the "mustache" namespace by default. This is
because they support etags and utags, which are not the standard means
of i18n interpolation.

Options relating to translation:
- i18n_namespace - Sets the namespace containing a Mustache's i18n keys
- locale - Override translation locale during render (I18n.locale by
  default)

Some caveats:
- Use of tags other than {{}} and {{{}}} inside an i18n string has
  unspecified behavior. It certainly isn't _intended_ to work, so any
  success had is purely by accident.

Rationale:

While it's possible to implement I18n by handling translations in each
view class, it's less than optimal to do so. If you want to support true
i18n interpolation, then you're forced to provide interpolation
variables from within the view class, and the view class may not have
access to all the information required to supply those variables.

An alternative is to use lambda return values, which of course could
perform the translation as a filter, but this is somewhat more
laborious, since the responsibility is now on the user to create a
mapping between the attributes of the view and those inside the locale
file.

Regarding the implementation itself:

I chose `%` as the sigil both because its appearance brings to mind both
the current `%{}` interpolation syntax and the notion of key/value pairs
in general (to this former Perl guy). `$` was chosen for the unescaped
version for proximity to `%`.

One thing I did take the opportunity to do, while I was in here, was
improve the handling of lambda return values to a section tag. While the
LoD violation here is a bit offputting, and could certainly be
refactored out, I find the notion of setting the otag and ctag on a
`tokenizer` for the template to be more readable than defining a
singleton method which then must duplicate the logic in the Template
class's tokens method with modifications.
