### PR TITLE
Fixed a logical error in the documentation.

### DIFF
--- a/man/mustache.5
+++ b/man/mustache.5
@@ -148,9 +148,9 @@ Template:
 .nf
 
 Shown\.
-{{#nothin}}
+{{#person}}
   Never shown!
-{{/nothin}}
+{{/person}}
 .
 .fi
 .
@@ -164,7 +164,7 @@ Hash:
 .nf
 
 {
-  "person": true
+  "person": false
 }
 .
 .fi

--- a/man/mustache.5.html
+++ b/man/mustache.5.html
@@ -175,15 +175,15 @@ list, the HTML between the pound and slash will not be displayed.</p>
 <p>Template:</p>
 
 <pre><code>Shown.
-{{#nothin}}
+{{#person}}
   Never shown!
-{{/nothin}}
+{{/person}}
 </code></pre>
 
 <p>Hash:</p>
 
 <pre><code>{
-  "person": true
+  "person": false
 }
 </code></pre>
 

--- a/man/mustache.5.ron
+++ b/man/mustache.5.ron
@@ -102,14 +102,14 @@ list, the HTML between the pound and slash will not be displayed.
 Template:
 
     Shown.
-    {{#nothin}}
+    {{#person}}
       Never shown!
-    {{/nothin}}
+    {{/person}}
 
 Hash:
 
     {
-      "person": true
+      "person": false
     }
 
 Output:


### PR DESCRIPTION
The documentation states that if a key is present and it
has a value of false or an empty list, then the content
between the pound sign and slash will not be shown.

The documentation had the key "person" with a true value,
which means that what {{#person}} {{/person}} was wrapping
would infact be shown.  The output however did not include
the contents of what {{#person}} {{/person}} wrapped.

If person is true, then the content should be shown, if
false, then not.
# Checklist
- [x] Rebase
- [x] Change template
- [x] Remove extra comma from the hash
- [x] squash commits
