### PR TITLE
Fix docs about variable name resolving

### DIFF
--- a/man/mustache.5.ron
+++ b/man/mustache.5.ron
@@ -50,9 +50,9 @@ or tag key. Let's talk about the different types of tags.
 
 The most basic tag type is the variable. A `{{name}}` tag in a basic
 template will try to find the `name` key in the current context. If
-there is no `name` key, parent contexts (starting from the deepest
-one) will be checked. If the top context is reached and the `name`
-key is still not found, nothing will be rendered.
+there is no `name` key, the parent contexts will be checked recursively.
+If the top context is reached and the `name` key is still not found,
+nothing will be rendered.
 
 All variables are HTML escaped by default. If you want to return
 unescaped HTML, use the triple mustache: `{{{name}}}`.


### PR DESCRIPTION
I've tried to make docs more precise.

The problem is in difference between docs and specs. Namely, in spec https://github.com/mustache/spec/blob/master/specs/sections.yml#L67 variable name is searched not only in the current context but in all its parents too. But the docs say that only current context will be checked.

Here is the discussion of the problem: https://github.com/mustache/mustache.github.com/issues/30
