### PR TITLE
Add note about Ruby >= 2.0 escaping `'`

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,9 @@ Escaping
 --------
 
 Mustache does escape all values when using the standard double
-Mustache syntax. Characters which will be escaped: `& \ " < >`. To
-disable escaping, simply use triple mustaches like
-`{{{unescaped_variable}}}`.
+Mustache syntax. Characters which will be escaped: `& \ " < >` (as 
+well as `'` in Ruby `>= 2.0`). To disable escaping, simply use triple
+mustaches like `{{{unescaped_variable}}}`.
 
 Example: Using `{{variable}}` inside a template for `5 > 2` will
 result in `5 &gt; 2`, where as the usage of `{{{variable}}}` will


### PR DESCRIPTION
In 2012 as Ruby 2.0 was being developed it was requested that single quotes (') be escaped by `CGI.escapeHTML` which Mustache uses under the hood to do the safe insertion. This change was made in https://github.com/ruby/ruby/commit/c47cca2f
