### PR TITLE
Use rbx-2 instead of rbx-2.1.1 for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ rvm:
   - 1.9.3
   - 2.1.0
   - jruby-19mode
-  - rbx-2.1.1
+  - rbx-2
 
 matrix:
   allow_failures:
     - rvm:
       - jruby-19mode
-      - rbx-2.1.1
+      - rbx-2


### PR DESCRIPTION
This ensures Travis auto upgrades to new versions of Rubinius 2.x.
