### PR TITLE
Always cast to hash on hash-like object lookups

### DIFF
--- a/lib/mustache/context.rb
+++ b/lib/mustache/context.rb
@@ -129,7 +129,7 @@ class Mustache
     # @return [Object] The value of key in object if it is found, and default otherwise.
     #
     def find(obj, key, default = nil)
-      return find_in_hash(obj, key, default) if obj.respond_to?(:to_hash)
+      return find_in_hash(obj.to_hash, key, default) if obj.respond_to?(:to_hash)
 
       key = to_tag(key)
       return default unless obj.respond_to?(key)
@@ -147,7 +147,8 @@ class Mustache
       key.to_s.include?('-') ? key.to_s.tr('-', '_') : key
     end
 
-    def find_in_hash obj, key, default
+    # Fetches a hash key if it exists, or returns the given default.
+    def find_in_hash(obj, key, default)
       return obj[key]      if obj.has_key?(key)
       return obj[key.to_s] if obj.has_key?(key.to_s)
 

--- a/test/mustache_test.rb
+++ b/test/mustache_test.rb
@@ -739,4 +739,20 @@ FROM
   DUMMY1
 template
   end
+
+  def test_cast_to_hash_in_context
+    hashlike = Object.new
+    def hashlike.title
+      'title'
+    end
+    def hashlike.to_hash
+      { title: 'title' }
+    end
+
+    template = '%%{{title}}%%'
+
+    assert_equal '%%title%%', Mustache.render(template, hashlike)
+
+  end
+
 end


### PR DESCRIPTION
Fixes a duck typing issue where objects that happen to implement `:to_hash` were being dispatched to the `Context#find_in_hash` method, without any guarantee that they provide the hash API directly.

This avoids a problem when using external attribute model libraries (eg: [Virtus](https://github.com/solnic/virtus)) that attach a `:to_hash` method to objects.

Without the explicit type cast, an error happens due to the `:has_key?` and `:fetch` methods being invoked on objects which aren’t actually guaranteed to be hashes. See the test case for an example of how this breaks in practice.

This is a bare minimum fix which illustrates what’s happening. There may be a better way to fix this, that avoids `respond_to?(:to_hash)` shortcutting direct lookups of attributes on the object.