### PR TITLE
Fix -v option

### DIFF
--- a/bin/mustache
+++ b/bin/mustache
@@ -49,7 +49,7 @@ class Mustache
         opts.separator "Common Options:"
 
         opts.on("-v", "--version", "Print the version") do |v|
-          puts "Mustache v#{Mustache::Version}"
+          puts "Mustache v#{Mustache::VERSION}"
           exit
         end
 


### PR DESCRIPTION
```
$ mustache -v
/usr/local/lib/ruby/gems/2.1.0/gems/mustache-1.0.0/bin/mustache:52:in `block (2 levels) in parse_options': uninitialized constant Mustache::Version (NameError)
    from /usr/local/lib/ruby/2.1.0/optparse.rb:1390:in `call'
    from /usr/local/lib/ruby/2.1.0/optparse.rb:1390:in `block in parse_in_order'
    from /usr/local/lib/ruby/2.1.0/optparse.rb:1346:in `catch'
    from /usr/local/lib/ruby/2.1.0/optparse.rb:1346:in `parse_in_order'
    from /usr/local/lib/ruby/2.1.0/optparse.rb:1340:in `order!'
    from /usr/local/lib/ruby/2.1.0/optparse.rb:1432:in `permute!'
    from /usr/local/lib/ruby/2.1.0/optparse.rb:1454:in `parse!'
    from /usr/local/lib/ruby/gems/2.1.0/gems/mustache-1.0.0/bin/mustache:64:in `parse_options'
    from /usr/local/lib/ruby/gems/2.1.0/gems/mustache-1.0.0/bin/mustache:94:in `<top (required)>'
    from /usr/local/bin/mustache:23:in `load'
    from /usr/local/bin/mustache:23:in `<main>'
```