### PR TITLE
Enable spec tests again

### DIFF
--- a/test/spec_test.rb
+++ b/test/spec_test.rb
@@ -59,7 +59,7 @@ Dir[spec_files].each do |file|
 
   test_suite.class_eval do
     spec['tests'].each do |test|
-      define_method :"test - #{test['name']}" do
+      define_method :"test_spec - #{test['name']}" do
         setup_partials(test)
         assert_mustache_spec(test)
       end


### PR DESCRIPTION
Spec tests were not being run, as the test method names
did not match minitest pattern "test_*".