### PR TITLE
Fix array of array iteration

### DIFF
--- a/lib/mustache/context.rb
+++ b/lib/mustache/context.rb
@@ -140,6 +140,10 @@ class Mustache
       meth.arity == 1 ? meth.to_proc : meth.call
     end
 
+    def current
+      @stack.first
+    end
+
 
     private
 

--- a/lib/mustache/generator.rb
+++ b/lib/mustache/generator.rb
@@ -175,7 +175,7 @@ class Mustache
     end
 
     def on_fetch(names)
-      return "ctx[:to_s]" if names.empty?
+      return "ctx.current" if names.empty?
 
       names = names.map { |n| n.to_sym }
 


### PR DESCRIPTION
When resolving references to self (either with {{.}} or {{#.}})
Mustache::Generator was generating code that called #to_s on
the current context object, instead of actually returning it.

This caused iteration on self to break, as it was converted
to a string, breaking Array detection.