### PR TITLE
Reword description of {{{name}}} and {{&name}}

### DIFF
--- a/man/mustache.1
+++ b/man/mustache.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "MUSTACHE" "1" "October 2014" "DEFUNKT" "Mustache Manual"
+.TH "MUSTACHE" "1" "February 2015" "DEFUNKT" "Mustache Manual"
 .
 .SH "NAME"
 \fBmustache\fR \- Mustache processor

--- a/man/mustache.1.html
+++ b/man/mustache.1.html
@@ -204,7 +204,7 @@ data
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'>DEFUNKT</li>
-    <li class='tc'>October 2014</li>
+    <li class='tc'>February 2015</li>
     <li class='tr'>mustache(1)</li>
   </ol>
 

--- a/man/mustache.5
+++ b/man/mustache.5
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "MUSTACHE" "5" "October 2014" "DEFUNKT" "Mustache Manual"
+.TH "MUSTACHE" "5" "February 2015" "DEFUNKT" "Mustache Manual"
 .
 .SH "NAME"
 \fBmustache\fR \- Logic\-less templates\.
@@ -69,10 +69,10 @@ Tags are indicated by the double mustaches\. \fB{{person}}\fR is a tag, as is \f
 The most basic tag type is the variable\. A \fB{{name}}\fR tag in a basic template will try to find the \fBname\fR key in the current context\. If there is no \fBname\fR key, the parent contexts will be checked recursively\. If the top context is reached and the \fBname\fR key is still not found, nothing will be rendered\.
 .
 .P
-All variables are HTML escaped by default\. If you want to return unescaped HTML, use the triple mustache: \fB{{{name}}}\fR\.
+All variables are HTML escaped by default\. If you want to return raw contents without escaping, use the triple mustache: \fB{{{name}}}\fR\.
 .
 .P
-You can also use \fB&\fR to unescape a variable: \fB{{& name}}\fR\. This may be useful when changing delimiters (see "Set Delimiter" below)\.
+You can also use \fB&\fR to return its raw contents: \fB{{& name}}\fR\. This may be useful when changing delimiters (see "Set Delimiter" below)\.
 .
 .P
 By default a variable "miss" returns an empty string\. This can usually be configured in your Mustache library\. The Ruby version of Mustache supports raising an exception in this situation, for instance\.

--- a/man/mustache.5.html
+++ b/man/mustache.5.html
@@ -125,10 +125,10 @@ there is no <code>name</code> key, the parent contexts will be checked recursive
 If the top context is reached and the <code>name</code> key is still not found,
 nothing will be rendered.</p>
 
-<p>All variables are HTML escaped by default. If you want to return
-unescaped HTML, use the triple mustache: <code>{{{name}}}</code>.</p>
+<p>All variables are HTML escaped by default. If you want to return raw contents
+without escaping, use the triple mustache: <code>{{{name}}}</code>.</p>
 
-<p>You can also use <code>&amp;</code> to unescape a variable: <code>{{&amp; name}}</code>. This may be
+<p>You can also use <code>&amp;</code> to return its raw contents: <code>{{&amp; name}}</code>. This may be
 useful when changing delimiters (see "Set Delimiter" below).</p>
 
 <p>By default a variable "miss" returns an empty string. This can usually
@@ -415,7 +415,7 @@ markup."</p>
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'>DEFUNKT</li>
-    <li class='tc'>October 2014</li>
+    <li class='tc'>February 2015</li>
     <li class='tr'>mustache(5)</li>
   </ol>
 

--- a/man/mustache.5.ron
+++ b/man/mustache.5.ron
@@ -54,10 +54,10 @@ there is no `name` key, the parent contexts will be checked recursively.
 If the top context is reached and the `name` key is still not found,
 nothing will be rendered.
 
-All variables are HTML escaped by default. If you want to return
-unescaped HTML, use the triple mustache: `{{{name}}}`.
+All variables are HTML escaped by default. If you want to return raw contents
+without escaping, use the triple mustache: `{{{name}}}`.
 
-You can also use `&` to unescape a variable: `{{& name}}`. This may be
+You can also use `&` to return its raw contents: `{{& name}}`. This may be
 useful when changing delimiters (see "Set Delimiter" below).
 
 By default a variable "miss" returns an empty string. This can usually


### PR DESCRIPTION
Removes reference to the word "unescaping", as it
might lead people to believe it actually undoes
html escaping.

Fixes #157