### PR TITLE
Cache compiled templates for partials

### DIFF
--- a/benchmarks/render_partials_benchmark.rb
+++ b/benchmarks/render_partials_benchmark.rb
@@ -1,0 +1,54 @@
+$:.unshift "lib"
+
+require "mustache"
+require "benchmark/ips"
+
+BASE_TEMPLATE = <<end_of_template
+<h2>Names</h2>
+{{#names}}
+  {{> user}}
+{{/names}}
+end_of_template
+
+PARTIAL_TEMPLATE = <<end_of_template
+<strong>{{name}}</strong>
+end_of_template
+
+one_name = [
+  {name: "Charlie Chaplin"},
+]
+
+data_10 = {
+  names: one_name * 10,
+}
+
+data_100 = {
+  names: one_name * 100,
+}
+
+data_1000 = {
+  names: one_name * 1000,
+}
+
+class Custom < Mustache
+  def partial(name)
+    PARTIAL_TEMPLATE
+  end
+end
+
+mustache = Custom.new
+mustache.template = BASE_TEMPLATE
+
+Benchmark.ips do |x|
+  x.report("render list of 10") do
+    mustache.render(data_10)
+  end
+
+  x.report("render list of 100") do
+    mustache.render(data_100)
+  end
+
+  x.report("render list of 1000") do
+    mustache.render(data_1000)
+  end
+end

--- a/lib/mustache/context.rb
+++ b/lib/mustache/context.rb
@@ -13,6 +13,7 @@ class Mustache
     #
     def initialize(mustache)
       @stack = [mustache]
+      @partial_template_cache = {}
     end
 
     # A {{>partial}} tag translates into a call to the context's
@@ -29,8 +30,12 @@ class Mustache
       # Indent the partial template by the given indentation.
       part = mustache.partial(name).to_s.gsub(/^/, indentation)
 
-      # Call the Mustache's `partial` method and render the result.
-      mustache.render(part, self)
+      # Get a template object for the partial and render the result.
+      template_for_partial(part).render(self)
+    end
+
+    def template_for_partial(partial)
+      @partial_template_cache[partial] ||= Template.new(partial)
     end
 
     # Find the first Mustache in the stack.


### PR DESCRIPTION
## Background

We made some [changes to the search results page for GOV.UK](https://github.com/alphagov/frontend/pull/784) and when we deployed the new code we saw a massive spike in CPU usage on our servers. We rolled back the change and investigated, and tracked the issue down to the Mustache gem.

The problem turned out to be the way we had used partials, and the way Mustache loads and renders them. We [found a work-around using a different partial structure](https://github.com/alphagov/frontend/pull/790), but since the original structure is easier to work with and likely to be repeated by another developer in the future, wanted to address the root cause in Mustache.

## What's the problem?

The [mustache manual](https://github.com/mustache/mustache/blob/master/man/mustache.5.ron#L272-L279) shows partials being used like:

```
base.mustache:
<h2>Names</h2>
{{#names}}
  {{> user}}
{{/names}}

user.mustache:
<strong>{{name}}</strong>
```

When using partials in this way, the `user.mustache` partial is loaded and compiled once for each iteration, even though the content is static.

Compiling a template is computationally expensive, especially for large and complex partials.

## What's changed?

This change caches a template object for each unique partial string after indentation is applied. Using the same template object each time the partial is used means that compilation only has to happen once.

## How much faster is it?

We've added a benchmark script for rendering partials. Doing a before and after comparison shows a ~16–20x speed up, depending on where it's run and how many list items need to be iterated through.

For complex partials the speed up can be better than ~50x. Here's a benchmark for the actual partial we were using for search results on GOV.UK: https://gist.github.com/evilstreak/9d3cc767fd0734bbb1f0

Here's a sample run of the benchmark included in this pull request:

### Before

```
Calculating -------------------------------------
   render list of 10    27.000  i/100ms
  render list of 100     2.000  i/100ms
 render list of 1000     1.000  i/100ms
-------------------------------------------------
   render list of 10    422.178  (±20.1%) i/s -      2.025k
  render list of 100     42.587  (±21.1%) i/s -    204.000
 render list of 1000      3.464  (±28.9%) i/s -     17.000
```

### After

```
Calculating -------------------------------------
   render list of 10   735.000  i/100ms
  render list of 100    65.000  i/100ms
 render list of 1000     6.000  i/100ms
-------------------------------------------------
   render list of 10      7.736k (±11.8%) i/s -     38.220k
  render list of 100    788.855  (±13.6%) i/s -      3.900k
 render list of 1000     73.325  (±17.7%) i/s -    360.000
```

## Possible objections

- **Risk of memory leaks.** A [previous pull request for caching templates](https://github.com/mustache/mustache/pull/173) was rejected because it would leak memory where templates were being dynamically generated or changed at runtime. That pull request redefined the `Template.new` method and used a class variable to store the cached versions of templates. Since we're using instance variables Ruby should be able to garbage collect them when they're finished with. That should mean we aren't at risk of introducing memory leaks.

- **String comparisons.** We're using the entire partial string to key the hash of cached templates. For large templates, that could be a very long string which will need to be used for comparisons. Ruby's `Hash` implementation is pretty efficient, so it's unlikely we could do better with a naive approach like calculating an MD5 hash of the partial to key the template with. Even if we could find a more efficient approach like that, we'd have to worry about the risk of collisions.

- **Lack of tests.** Since the behaviour of the system ought to be identical from the outside there isn't anything obvious to test. The extra benchmark demonstrates the difference in performance, and the existing tests for partials cover both cache hits and cache misses.