### PR TITLE
Treat empty strings as falsey values

### DIFF
--- a/lib/mustache/generator.rb
+++ b/lib/mustache/generator.rb
@@ -118,7 +118,7 @@ class Mustache
             p.compile(src)
           end
           t.render(ctx.dup)
-        else
+        elsif !v.nil? && !(v.respond_to?(:empty?) && v.empty?)
           # Shortcut when passed non-array
           v = [v] unless v.is_a?(Array) || v.is_a?(Mustache::Enumerable) || defined?(Enumerator) && v.is_a?(Enumerator)
 

--- a/test/mustache_test.rb
+++ b/test/mustache_test.rb
@@ -127,6 +127,14 @@ rendered
     assert_equal %Q'<p class="flash-notice" style="display: none;">', instance.render
   end
 
+  def test_sections_treat_empty_string_as_false
+    html = "Empty strings are {{#string}}Truthy{{/string}}{{^string}}Falsey{{/string}}"
+
+    instance = Mustache.new
+    instance.template = html
+    assert_equal "Empty strings are Falsey", instance.render(string: "")
+  end
+
   def test_simple
     assert_equal <<-end_simple, Simple.render
 Hello Chris


### PR DESCRIPTION
Mustache was treating empty strings both as truthy and falsey values.

This change resolves the inconsistency, but also brings Mustache's behavior more in line with Mustache.js's.

This resolves issue #206