### PR TITLE
Favor Symbol == <arbitrary type> over vice-versa

### DIFF
--- a/lib/mustache/context.rb
+++ b/lib/mustache/context.rb
@@ -114,7 +114,7 @@ class Mustache
         next if frame == self
 
         value = find(frame, name, :__missing)
-        return value if value != :__missing
+        return value if :__missing != value
       end
 
       if default == :__raise || mustache_in_stack.raise_on_context_miss?


### PR DESCRIPTION
Swapping the order of operands is a tiny thing:

```ruby
-        return value if value != :__missing
+        return value if :__missing != value
```

…but it results in always calling `Symbol#==`, instead of calling user types' `<=>(Symbol)` which might raise exceptions.

At present, exceptions raised by `<=>` are caught by `Comparable#==` and result in a warning, but [exceptions will bubble out as of Ruby 2.3](https://bugs.ruby-lang.org/issues/7688).