### PR TITLE
Raise on deep context miss

### DIFF
--- a/lib/mustache/context.rb
+++ b/lib/mustache/context.rb
@@ -163,7 +163,11 @@ class Mustache
       return obj[key]      if obj.has_key?(key)
       return obj[key.to_s] if obj.has_key?(key.to_s)
 
-      obj.fetch(key, default)
+      if mustache_in_stack.raise_on_context_miss?
+        raise ContextMiss.new("Can't find #{key} in #{obj}")
+      else
+        obj.fetch(key, default)
+      end
     end
   end
 end

--- a/test/mustache_test.rb
+++ b/test/mustache_test.rb
@@ -430,6 +430,19 @@ Benvolio is 15
     end
   end
 
+  def test_not_found_deep_in_context_raises_when_asked_to
+    instance = Mustache.new
+    instance.raise_on_context_miss = true
+
+    instance[:list] = { :item => { :value => 1234 } }
+
+    instance.template = '{{list.item.no_value}}'
+
+    assert_raises Mustache::ContextMiss do
+      instance.render
+    end
+  end
+
   def test_knows_when_its_been_compiled_when_set_with_string
     klass = Class.new(Mustache)
 


### PR DESCRIPTION
Using dot notation does not raise ContextMiss if something deep in a hash is missing.
Not entirely sure this is the right way to implement it but all the tests still pass.