### PR TITLE
Allow hyphens in tags

### DIFF
--- a/lib/mustache/context.rb
+++ b/lib/mustache/context.rb
@@ -138,8 +138,11 @@ class Mustache
     def find(obj, key, default = nil)
       return find_in_hash(obj.to_hash, key, default) if obj.respond_to?(:to_hash)
 
-      key = to_tag(key)
-      return default unless obj.respond_to?(key)
+      unless obj.respond_to?(key)
+        # no match for the key, but it may include a hyphen, so try again replacing hyphens with underscores.
+        key = key.to_s.tr('-', '_')
+        return default unless obj.respond_to?(key)
+      end
 
       meth = obj.method(key) rescue proc { obj.send(key) }
       meth.arity == 1 ? meth.to_proc : meth.call
@@ -151,12 +154,6 @@ class Mustache
 
 
     private
-
-
-    # If a class, we need to find tags (methods) per Parser::ALLOWED_CONTENT.
-    def to_tag key
-      key.to_s.include?('-') ? key.to_s.tr('-', '_') : key
-    end
 
     # Fetches a hash key if it exists, or returns the given default.
     def find_in_hash(obj, key, default)

--- a/test/fixtures/liberal.mustache
+++ b/test/fixtures/liberal.mustache
@@ -1,1 +1,1 @@
-{{first-name}} {{middle_name!}} {{lastName?}}
+{{first-name}} {{middle_name!}} {{lastName?}} {{street-address}}

--- a/test/fixtures/liberal.rb
+++ b/test/fixtures/liberal.rb
@@ -14,6 +14,10 @@ class Liberal < Mustache
   def lastName?
     'sheurs'
   end
+
+  define_method :'street-address' do
+    '123 Somewhere St'
+  end
 end
 
 if $0 == __FILE__

--- a/test/mustache_test.rb
+++ b/test/mustache_test.rb
@@ -531,7 +531,7 @@ Benvolio is 15
 
   def test_liberal_tag_names_in_class
     assert_equal <<-end_liberal, Liberal.render
-kevin j sheurs
+kevin j sheurs 123 Somewhere St
 end_liberal
   end
 


### PR DESCRIPTION
Due to legacy requirements, I need to have tags with hyphens, and I need the original tag name passed to method_missing -- unfortunately changing the underscores back to hyphens is not sufficient because some tags may contain underscores (sigh).

This change checks to see if the view object responds to the original key before replacing hyphens with underscores, and if it finds no match it will then do the replacement and try again.

All tests pass, and I've modified an existing test to test this new behaviour.

Thanks!