### PR TITLE
Prepend 'Mustache::' to Parser call to prevent namespace failures

### DIFF
--- a/lib/mustache/generator.rb
+++ b/lib/mustache/generator.rb
@@ -113,7 +113,7 @@ class Mustache
         elsif v.is_a?(Proc)
           t = Mustache::Template.new(v.call(#{raw.inspect}).to_s)
           def t.tokens(src=@source)
-            p = Parser.new
+            p = Mustache::Parser.new
             p.otag, p.ctag = #{delims.inspect}
             p.compile(src)
           end


### PR DESCRIPTION
We had an error, where a wrong namespace has been used and therefore the Parser could not been instantiated. This commit fixed our problem.