### PR TITLE
Performance tweaks

### DIFF
--- a/benchmarks/render_collection_benchmark.rb
+++ b/benchmarks/render_collection_benchmark.rb
@@ -56,16 +56,20 @@ data_1000 = {
   }
 end
 
+view = Mustache.new
+view.template = template
+view.render # Call render once so the template will be compiled
+
 Benchmark.ips do |x|
   x.report("render list of 10") do |times|
-    Mustache.render(template, data_10)
+    view.render(data_10)
   end
 
   x.report("render list of 100") do |times|
-    Mustache.render(template, data_100)
+    view.render(data_100)
   end
 
   x.report("render list of 1000") do |times|
-    Mustache.render(template, data_1000)
+    view.render(data_1000)
   end
 end

--- a/benchmarks/render_collection_profile.rb
+++ b/benchmarks/render_collection_profile.rb
@@ -37,10 +37,14 @@ end
 # Uncomment to measure object allocations. Requires ruby 2.0.0
 # RubyProf.measure_mode = RubyProf::ALLOCATIONS
 
+view = Mustache.new
+view.template = template
+view.render # Call render once so the template will be compiled
+
 RubyProf.start
 
 500.times do
-  Mustache.render(template, data)
+  view.render(data)
 end
 
 result = RubyProf.stop

--- a/benchmarks/render_lambda_benchmark.rb
+++ b/benchmarks/render_lambda_benchmark.rb
@@ -1,0 +1,50 @@
+$:.unshift "lib"
+
+require "mustache"
+require "benchmark/ips"
+
+BASE_TEMPLATE = <<end_of_template
+<h2>Lambdas</h2>
+{{#lambdas}}
+  {{#lambda}}
+    Here is some text inside the lambda.\n
+    Also a variable is present: {{name}}.
+  {{/lambda}}
+{{/lambdas}}
+end_of_template
+
+one_name = [
+  {
+    name: "Charlie Chaplin",
+    lambda: lambda {|text| "\n--\n#{text}\n--\n" }
+  },
+]
+
+data_10 = {
+  lambdas: one_name * 10,
+}
+
+data_100 = {
+  lambdas: one_name * 100,
+}
+
+data_1000 = {
+  lambdas: one_name * 1000,
+}
+
+mustache = Mustache.new
+mustache.template = BASE_TEMPLATE
+
+Benchmark.ips do |x|
+  x.report("render list of 10") do
+    mustache.render(data_10)
+  end
+
+  x.report("render list of 100") do
+    mustache.render(data_100)
+  end
+
+  x.report("render list of 1000") do
+    mustache.render(data_1000)
+  end
+end

--- a/lib/mustache.rb
+++ b/lib/mustache.rb
@@ -279,7 +279,7 @@ class Mustache
   end
 
   def templateify(obj)
-    self.class.templateify(obj, @options)
+    self.class.templateify(obj, @options.merge(:partial_resolver => self.method(:partial)))
   end
 
   # Return the value of the configuration setting on the superclass, or return

--- a/lib/mustache.rb
+++ b/lib/mustache.rb
@@ -74,6 +74,12 @@ require 'mustache/utils'
 #
 class Mustache
 
+  # Initialize a new mustache instance.
+  # @param [Hash] options An options hash
+  def initialize(options = {})
+    @options = options
+  end
+
   # Instantiates an instance of this class and calls `render` with
   # the passed args.
   #
@@ -266,13 +272,14 @@ class Mustache
     Mustache::Utils::String.new(classified).underscore(view_namespace)
   end
 
-  # @param [Template,String] obj Turns `obj` into a template
-  def self.templateify(obj)
-    obj.is_a?(Template) ? obj : Template.new(obj)
+  # @param [Template,String] obj      Turns `obj` into a template
+  # @param [Hash]            options  Options for template creation
+  def self.templateify(obj, options = {})
+    obj.is_a?(Template) ? obj : Template.new(obj, options)
   end
 
   def templateify(obj)
-    self.class.templateify(obj)
+    self.class.templateify(obj, @options)
   end
 
   # Return the value of the configuration setting on the superclass, or return

--- a/lib/mustache.rb
+++ b/lib/mustache.rb
@@ -279,7 +279,7 @@ class Mustache
   end
 
   def templateify(obj)
-    self.class.templateify(obj, @options.merge(:partial_resolver => self.method(:partial)))
+    self.class.templateify(obj, {:partial_resolver => self.method(:partial)}.merge(@options))
   end
 
   # Return the value of the configuration setting on the superclass, or return

--- a/lib/mustache/generator.rb
+++ b/lib/mustache/generator.rb
@@ -109,7 +109,7 @@ class Mustache
       # the returned lambda result as mustache source
       proc_handling = if @option_static_lambdas
         <<-compiled
-          v.call(#{raw.inspect}).to_s
+          v.call(lambda {|v| #{code}}.call(v)).to_s
         compiled
       else
         <<-compiled

--- a/lib/mustache/parser.rb
+++ b/lib/mustache/parser.rb
@@ -103,8 +103,9 @@ EOF
 
     # The opening tag delimiter. This may be changed at runtime.
     def otag=(value)
-      @otag_regex     = /([ \t]*)?#{regexp(value)}/
-      @otag_not_regex = /(^[ \t]*)?#{regexp(value)}/
+      regex = regexp value
+      @otag_regex     = /([ \t]*)?#{regex}/
+      @otag_not_regex = /(^[ \t]*)?#{regex}/
       @otag = value
     end
 
@@ -275,7 +276,7 @@ EOF
     # Used to quickly convert a string into a regular expression
     # usable by the string scanner.
     def regexp(thing)
-      /#{Regexp.escape(thing)}/ if thing
+      Regexp.new Regexp.escape(thing) if thing
     end
 
     # Raises a SyntaxError. The message should be the name of the

--- a/lib/mustache/parser.rb
+++ b/lib/mustache/parser.rb
@@ -340,7 +340,7 @@ EOF
 
     def scan_tag_open_partial content, fetch, padding, pre_match_position
       @result << if @option_inline_partials_at_compile_time
-        partial = @partial_resolver.call(content)
+        partial = @partial_resolver.call content
         partial.gsub!(/^/, padding) unless padding.empty?
         self.class.new(@options).compile partial
       else

--- a/lib/mustache/parser.rb
+++ b/lib/mustache/parser.rb
@@ -89,7 +89,7 @@ EOF
     # Accepts an options hash which does nothing but may be used in
     # the future.
     def initialize(options = {})
-      @options = {}
+      @options = options
       @option_inline_partials_at_compile_time = options[:inline_partials_at_compile_time]
       if @option_inline_partials_at_compile_time
         @partial_resolver = options[:partial_resolver]

--- a/lib/mustache/parser.rb
+++ b/lib/mustache/parser.rb
@@ -108,7 +108,7 @@ EOF
       @otag = value
     end
 
-    # The closing tag delimiter. This too may be changed at runtime.q
+    # The closing tag delimiter. This too may be changed at runtime.
     def ctag=(value)
       @ctag_regex = regexp value
       @ctag = value

--- a/lib/mustache/parser.rb
+++ b/lib/mustache/parser.rb
@@ -340,7 +340,9 @@ EOF
 
     def scan_tag_open_partial content, fetch, padding, pre_match_position
       @result << if @option_inline_partials_at_compile_time
-        self.class.new(@options).compile @partial_resolver.call(content)
+        partial = @partial_resolver.call(content)
+        partial.gsub!(/^/, padding) unless padding.empty?
+        self.class.new(@options).compile partial
       else
         [:mustache, :partial, content, offset, padding]
       end

--- a/lib/mustache/template.rb
+++ b/lib/mustache/template.rb
@@ -18,9 +18,10 @@ class Mustache
     attr_reader :source
 
     # Expects a Mustache template as a string along with a template
-    # path, which it uses to find partials.
-    def initialize(source)
+    # path, which it uses to find partials. Options may be passed.
+    def initialize(source, options = {})
       @source = source
+      @options = options
     end
 
     # Renders the `@source` Mustache template using the given
@@ -46,7 +47,7 @@ class Mustache
     # Does the dirty work of transforming a Mustache template into an
     # interpolation-friendly Ruby string.
     def compile(src = @source)
-      Generator.new.compile(tokens(src))
+      Generator.new(@options).compile(tokens(src))
     end
     alias_method :to_s, :compile
 
@@ -55,7 +56,7 @@ class Mustache
     # @return [Array] Array of tokens.
     #
     def tokens(src = @source)
-      Parser.new.compile(src)
+      Parser.new(@options).compile(src)
     end
 
     # Returns an array of tags.

--- a/test/mustache_test.rb
+++ b/test/mustache_test.rb
@@ -496,6 +496,24 @@ Benvolio is 15
     assert_equal 1, view.calls
   end
 
+  def test_sections_returning_lambdas_get_called_dynamically_with_text
+    view = Mustache.new
+    view.template       = '{{name}}'
+    view[:name]         = lambda { '{{dynamic_name}}' }
+    view[:dynamic_name] = 'Chris'
+
+    assert_equal "Chris", view.render.chomp
+  end
+
+  def test_sections_returning_lambdas_get_not_called_dynamically_with_text_if_static
+    view = Mustache.new :static_lambdas => true
+    view.template       = '{{name}}'
+    view[:name]         = lambda { '{{dynamic_name}}' }
+    view[:dynamic_name] = 'Chris'
+
+    assert_equal "{{dynamic_name}}", view.render.chomp
+  end
+
   def test_sections_which_refer_to_unary_method_call_them_as_proc
     kls = Class.new(Mustache) do
       def unary_method(arg)

--- a/test/mustache_test.rb
+++ b/test/mustache_test.rb
@@ -362,7 +362,7 @@ data
       end
 
       def each *args, &block
-        @people.each *args, &block
+        @people.each(*args, &block)
       end
     end
 

--- a/test/partial_test.rb
+++ b/test/partial_test.rb
@@ -20,6 +20,19 @@ end_partial
     assert_equal "Again, success!", view.render
   end
 
+  def test_partial_inlining
+    view = Mustache.new :inline_partials_at_compile_time => true
+    view.template = '{{> test/fixtures/inner_partial}}'
+    view[:title] = 'success'
+
+    # Test the rendered result first
+    assert_equal "Again, success!", view.render
+
+    # Now the template should be compiled.
+    # There should be no :partial instruction as the partial has been in-lined.
+    assert_equal false, view.template.tokens.flatten.include?(:partial)
+  end
+
   def test_view_partial_inherits_context
     klass = Class.new(TemplatePartial)
     view = klass.new


### PR DESCRIPTION
We are using mustache in different projects (all along rails) and having quite a few performance issues caused by mustache.

One major problem is the dynamic interpretation of lambdas. Assume the following mustache source:
`{{#greeting}}John{{/greeting}}`
with the view:
`greeting = lambda {|text| "Hey ho #{text}, want's up?!"}`

The issue is here, that mustache creates a complete new mustache object for the string "Hey ho John, what's up?!" which is compiled and rendered at every request on runtime. This pull request contains an option which allows to disable this behavior.

**So you are changing the mustache behavior, what will be broken?**
That's a good question! The following example will no longer work if `:static_lambdas` is explicitly set to true (see tests). Assume the following setup:
```
view = Mustache.new :static_lambdas => STATIC
view.template = '{{name}}'
view[:name] = lambda { '{{dynamic_name}}' }
view[:dynamic_name] = 'Chris'

result = view.render
```

**Before (e.g. STATIC = false)**:
`Chris`

**After (e.g. STATIC = true)**:
`{{dynamic_name}}`

We did not have a single line in one of our projects, which requires such a behavior. I even had to add a dedicated test (`test_sections_returning_lambdas_get_called_dynamically_with_text`) to create a failing one ;).

**What's the speedup?**
For a few pages, which are using relatively many lambdas as asset helpers, we were able to cut the rendering time by 50%.