### PR TITLE
Hashes with default_procs may lazily fetch values.

### DIFF
--- a/lib/mustache/context.rb
+++ b/lib/mustache/context.rb
@@ -159,6 +159,7 @@ class Mustache
     def find_in_hash(obj, key, default)
       return obj[key]      if obj.has_key?(key)
       return obj[key.to_s] if obj.has_key?(key.to_s)
+      return obj[key]      if obj.respond_to?(:default_proc) && obj.default_proc && obj[key]
 
       # If default is :__missing then we are from #fetch which is hunting through the stack
       # If default is nil then we are reducing dot notation

--- a/test/mustache_test.rb
+++ b/test/mustache_test.rb
@@ -724,6 +724,23 @@ text
     end
   end
 
+  def test_hash_default_proc
+    template = <<template
+{{greetings.Peter}}
+{{greetings.Paul}}
+{{greetings.Mary}}
+template
+    data = {
+      'greetings' => Hash.new { |hash, key| hash[key] = "Hello, #{key}!" }
+    }
+
+    assert_equal <<expected, Mustache.render(template, data)
+Hello, Peter!
+Hello, Paul!
+Hello, Mary!
+expected
+  end
+
   def test_array_of_arrays
     template = <<template
 {{#items}}


### PR DESCRIPTION
This is useful when the input to `Mustache.render` requires computation before the markup can be generated.