### PR TITLE
fix data.yml template.mustache | mustache example

### DIFF
--- a/man/mustache.1
+++ b/man/mustache.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "MUSTACHE" "1" "February 2015" "DEFUNKT" "Mustache Manual"
+.TH "MUSTACHE" "1" "November 2016" "DEFUNKT" "Mustache Manual"
 .
 .SH "NAME"
 \fBmustache\fR \- Mustache processor
@@ -75,7 +75,7 @@ $ cat template\.mustache
   Hi {{name}}!
 {{/names}}
 
-$ cat data\.yml template\.mustache | mustache
+$ mustache data\.yml template\.mustache
 Hi chris!
 Hi mark!
 Hi scott!
@@ -106,7 +106,7 @@ name: scott
 $ cat template\.mustache
 Hi {{name}}!
 
-$ cat data\.yml template\.mustache | mustache
+$ mustache data\.yml template\.mustache
 Hi chris!
 Hi mark!
 Hi scott!

--- a/man/mustache.1.html
+++ b/man/mustache.1.html
@@ -123,7 +123,7 @@ $ cat template.mustache
   Hi {{name}}!
 {{/names}}
 
-$ cat data.yml template.mustache | mustache
+$ mustache data.yml template.mustache
 Hi chris!
 Hi mark!
 Hi scott!
@@ -146,7 +146,7 @@ name: scott
 $ cat template.mustache
 Hi {{name}}!
 
-$ cat data.yml template.mustache | mustache
+$ mustache data.yml template.mustache
 Hi chris!
 Hi mark!
 Hi scott!
@@ -204,7 +204,7 @@ data
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'>DEFUNKT</li>
-    <li class='tc'>February 2015</li>
+    <li class='tc'>November 2016</li>
     <li class='tr'>mustache(1)</li>
   </ol>
 

--- a/man/mustache.1.ron
+++ b/man/mustache.1.ron
@@ -48,7 +48,7 @@ Now let's combine them.
       Hi {{name}}!
     {{/names}}
 
-    $ cat data.yml template.mustache | mustache
+    $ mustache data.yml template.mustache
     Hi chris!
     Hi mark!
     Hi scott!
@@ -70,7 +70,7 @@ For example:
     $ cat template.mustache
     Hi {{name}}!
 
-    $ cat data.yml template.mustache | mustache
+    $ mustache data.yml template.mustache
     Hi chris!
     Hi mark!
     Hi scott!

--- a/man/mustache.5
+++ b/man/mustache.5
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "MUSTACHE" "5" "February 2015" "DEFUNKT" "Mustache Manual"
+.TH "MUSTACHE" "5" "November 2016" "DEFUNKT" "Mustache Manual"
 .
 .SH "NAME"
 \fBmustache\fR \- Logic\-less templates\.

--- a/man/mustache.5.html
+++ b/man/mustache.5.html
@@ -415,7 +415,7 @@ markup."</p>
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'>DEFUNKT</li>
-    <li class='tc'>February 2015</li>
+    <li class='tc'>November 2016</li>
     <li class='tr'>mustache(5)</li>
   </ol>
 


### PR DESCRIPTION
The example given in the man page (mustache(1)) produces an error.

  $ cat data.yml template.mustache | mustache
  Unable to parse yaml!

However, the usage (mustache -h) has a working example.

  $ mustache data.yml template.mustache
  Hi chris!
  Hi mark!
  Hi scott!

Update the man page to use the working example.

Signed-off-by: Jeremiah Mahler <jmmahler@gmail.com>