### PR TITLE
Allow redefine initialize in Mustache descendants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ Gemfile.lock
 doc/*
 
 benchmarks/*.html
+
+/coverage/

--- a/lib/mustache.rb
+++ b/lib/mustache.rb
@@ -279,7 +279,9 @@ class Mustache
   end
 
   def templateify(obj)
-    self.class.templateify(obj, {:partial_resolver => self.method(:partial)}.merge(@options))
+    opts = {:partial_resolver => self.method(:partial)}
+    opts.merge!(@options) if @options.is_a?(Hash)
+    self.class.templateify(obj, opts)
   end
 
   # Return the value of the configuration setting on the superclass, or return

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,7 +1,9 @@
-require 'minitest/autorun'
-
 require 'simplecov'
-SimpleCov.start
+SimpleCov.start do
+  add_filter '/test/'
+end
+
+require 'minitest/autorun'
 
 Dir[File.dirname(__FILE__) + '/fixtures/*.rb'].each do |f|
   require f

--- a/test/mustache_test.rb
+++ b/test/mustache_test.rb
@@ -815,7 +815,17 @@ template
     template = '%%{{title}}%%'
 
     assert_equal '%%title%%', Mustache.render(template, hashlike)
-
   end
 
+  def test_instance_with_initialize_render
+    klass = Class.new(Mustache) do
+      def initialize(name)
+        @name = name
+      end
+      attr_reader :name
+    end
+
+    klass.template = "Hi {{name}}!"
+    assert_equal "Hi Dougal!", klass.new("Dougal").render
+  end
 end


### PR DESCRIPTION
Fix for error in version `1.0.4`:
```ruby
TypeError: no implicit conversion of nil into Hash
```