### PR TITLE
Raise correct error when closing unopened section

### DIFF
--- a/lib/mustache/parser.rb
+++ b/lib/mustache/parser.rb
@@ -323,12 +323,14 @@ EOF
 
     def scan_tag_close content, fetch, padding, pre_match_position
       section, pos, result = @sections.pop
+      if section.nil?
+        error "Closing unopened #{content.inspect}"
+      end
+
       raw = @scanner.pre_match[pos[3]...pre_match_position] + padding
       (@result = result).last << raw << [self.otag, self.ctag]
 
-      if section.nil?
-        error "Closing unopened #{content.inspect}"
-      elsif section != content
+      if section != content
         error "Unclosed section #{section.inspect}", pos
       end
     end

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -94,4 +94,68 @@ EOF
 
     assert_equal expected, tokens
   end
+
+  def test_unclosed_section
+    lexer = Mustache::Parser.new
+    exception = assert_raises Mustache::Parser::SyntaxError do
+      lexer.compile("{{#list}}")
+    end
+
+    expected = <<-EOF
+Unclosed section "list"
+  Line 1
+    {{#list}}
+          ^
+EOF
+
+    assert_equal expected, exception.message
+  end
+
+  def test_closing_unopened
+    lexer = Mustache::Parser.new
+    exception = assert_raises Mustache::Parser::SyntaxError do
+      lexer.compile("{{/list}}")
+    end
+
+    expected = <<-EOF
+Closing unopened "list"
+  Line 1
+    {{/list}}
+          ^
+EOF
+
+    assert_equal expected, exception.message
+  end
+
+  def test_unclosed_tag
+    lexer = Mustache::Parser.new
+    exception = assert_raises Mustache::Parser::SyntaxError do
+      lexer.compile("{{list")
+    end
+
+    expected = <<-EOF
+Unclosed tag
+  Line 1
+    {{list
+         ^
+EOF
+
+    assert_equal expected, exception.message
+  end
+
+  def test_illegal_content
+    lexer = Mustache::Parser.new
+    exception = assert_raises Mustache::Parser::SyntaxError do
+      lexer.compile("{{")
+    end
+
+    expected = <<-EOF
+Illegal content in tag
+  Line 1
+    {{
+     ^
+EOF
+
+    assert_equal expected, exception.message
+  end
 end


### PR DESCRIPTION
Previously we'd raise the wrong error:
```
> Mustache::Parser.new.compile("{{/list}}")
NoMethodError: undefined method `[]' for nil:NilClass
from mustache/lib/mustache/parser.rb:326:in `scan_tag_close'
```
This was because we were trying to use the section's position before checking if the section was valid.

I added some tests for the other parse errors to make sure they would all be raised correctly.