### PR TITLE
Implement `Mustache#escape`

### DIFF
--- a/lib/mustache.rb
+++ b/lib/mustache.rb
@@ -190,7 +190,22 @@ class Mustache
   end
 
   # Override this to provide custom escaping.
+  # By default it uses `CGI.escapeHTML`.
   #
+  # @example Overriding #escape
+  #   class PersonView < Mustache
+  #     def escape(value)
+  #       my_html_escape_method(value.to_s)
+  #     end
+  #   end
+  #
+  # @param [Object] value Value to escape.
+  # @return [String] Escaped content.
+  def escape(value)
+    self.escapeHTML(value.to_s)
+  end
+  
+  # Override this to provide custom escaping.
   # Example:
   #
   #   class PersonView < Mustache
@@ -199,6 +214,11 @@ class Mustache
   #     end
   #   end
   #
+  # @deprecated Use {#escape} instead.
+  #
+  #   Note that {#escape} can receive any kind of object.
+  #   If your override logic is expecting a string, you will
+  #   have to call to_s on it yourself.
   # @param [String] str String to escape.
   #
   # @return [String] Escaped HTML.

--- a/lib/mustache/context.rb
+++ b/lib/mustache/context.rb
@@ -51,12 +51,12 @@ class Mustache
 
     # Allows customization of how Mustache escapes things.
     #
-    # @param [String] str String to escape.
+    # @param [Object] value Value to escape.
     #
-    # @return [String] Escaped HTML string.
+    # @return [String] Escaped string.
     #
-    def escapeHTML(str)
-      mustache_in_stack.escapeHTML(str)
+    def escape(value)
+      mustache_in_stack.escape(value)
     end
 
     # Adds a new object to the context's internal stack.

--- a/lib/mustache/generator.rb
+++ b/lib/mustache/generator.rb
@@ -182,7 +182,7 @@ class Mustache
         if v.is_a?(Proc)
           v = #{@option_static_lambdas ? 'v.call' : 'Mustache::Template.new(v.call.to_s).render(ctx.dup)'}
         end
-        ctx.escapeHTML(v.to_s)
+        ctx.escape(v)
       compiled
     end
 

--- a/test/mustache_test.rb
+++ b/test/mustache_test.rb
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 require_relative 'helper'
+require 'json'
 
 class MustacheTest < Minitest::Test
   def test_instance_render
@@ -659,7 +660,7 @@ template
     assert_equal('[ 0 1 2 3 4 5 6 7 8 9 10 ]', MethodMissing.render)
   end
 
-  def test_custom_escaping
+  def test_custom_html_escaping
     view = Class.new(Mustache) do
       def escapeHTML(str)
         "pong"
@@ -667,6 +668,17 @@ template
     end
 
     assert_equal 'pong', view.render("{{thing}}", :thing => "nothing")
+    assert_equal 'nothing', Mustache.render("{{thing}}", :thing => "nothing")
+  end
+
+  def test_custom_escaping
+    view = Class.new(Mustache) do
+      def escape(str)
+        JSON.dump(str)
+      end
+    end
+
+    assert_equal '{ "key": "a\"b" }', view.render('{ "key": {{thing}} }', :thing => 'a"b')
     assert_equal 'nothing', Mustache.render("{{thing}}", :thing => "nothing")
   end
 


### PR DESCRIPTION
Mustache currently has a `Mustache#escapeHTML` method that can be overriden to customize the escaping of the values of `{{}}`. Given that the escaping does not necessarily have to be HTML, a more generic `Mustache#escape` will be added.

## Technical approach

* Introduce `Mustache#escape` that defaults to `Mustache#escapeHTML`
* Deprecate `Mustache#escapeHTML`