### PR TITLE
Allow multiple directories in template search path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ doc/*
 benchmarks/*.html
 
 /coverage/
+
+vendor/bundle
+.bundle

--- a/README.md
+++ b/README.md
@@ -167,8 +167,8 @@ follows the classic Ruby naming convention.
     TemplatePartial => ./template_partial.mustache
 
 You can set the search path using `Mustache.template_path`. Search multiple
-paths by delimiting them with colons. It can be set on a
-class by class basis:
+paths by delimiting them with your platform's 'path separator' (colon on Unix).
+It can be set on a class by class basis:
 
 ```ruby
 class Simple < Mustache

--- a/README.md
+++ b/README.md
@@ -166,7 +166,8 @@ follows the classic Ruby naming convention.
 
     TemplatePartial => ./template_partial.mustache
 
-You can set the search path using `Mustache.template_path`. It can be set on a
+You can set the search path using `Mustache.template_path`. Search multiple
+paths by delimiting them with colons. It can be set on a
 class by class basis:
 
 ```ruby

--- a/lib/mustache.rb
+++ b/lib/mustache.rb
@@ -179,14 +179,11 @@ class Mustache
   # reading templates from a database. It will be rendered by the
   # context, so all you need to do is return a string.
   def partial(name)
-    path = "#{template_path}/#{name}.#{template_extension}"
+    partialpath = template_path.map{|p| "#{p}/#{name}.#{template_extension}" }.find{|pf| File.readable? pf}
 
-    begin
-      File.read(path)
-    rescue
-      raise if raise_on_context_miss?
-      ""
-    end
+    raise RuntimeError.new("Can't find partial #{name}") if not partialpath and raise_on_context_miss?
+
+    partialpath ? File.read(partialpath) : ""
   end
 
   # Override this to provide custom escaping.

--- a/lib/mustache/settings.rb
+++ b/lib/mustache/settings.rb
@@ -9,7 +9,7 @@ class Mustache
   # The template path informs your Mustache view where to look for its
   # corresponding template. It is an array of paths, by default containing
   # one entry:  the current directory (".")
-  # When setting up from a string, use ':' delimiters to create a search path
+  # When setting up from a string, use path delimiters to create a search path
   # When the template_file is requested, a search is done to find the file in the
   # path, this is then stored as the name.
   #
@@ -17,7 +17,7 @@ class Mustache
   # for "app/templates/stat.mustache"
 
   def self.setup_path path
-    path = path.split(':') if path.is_a? String
+    path = path.split(File::PATH_SEPARATOR) if path.is_a? String
     path.map{|p| File.expand_path(p)}
   end
 

--- a/lib/mustache/settings.rb
+++ b/lib/mustache/settings.rb
@@ -7,38 +7,43 @@ class Mustache
   #
 
   # The template path informs your Mustache view where to look for its
-  # corresponding template. By default it's the current directory (".")
+  # corresponding template. It is an array of paths, by default containing
+  # one entry:  the current directory (".")
+  # When setting up from a string, use ':' delimiters to create a search path
+  # When the template_file is requested, a search is done to find the file in the
+  # path, this is then stored as the name.
   #
   # A class named Stat with a template_path of "app/templates" will look
   # for "app/templates/stat.mustache"
 
+  def self.setup_path path
+    path = path.split(':') if path.is_a? String
+    path.map{|p| File.expand_path(p)}
+  end
+
   def self.template_path
-    @template_path ||= inheritable_config_for :template_path, '.'
+    @template_path ||= setup_path(inheritable_config_for(:template_path, '.'))
   end
 
   def self.template_path=(path)
-    @template_path = File.expand_path(path)
+    @template_path = setup_path(path)
     @template = nil
   end
 
   def template_path
     @template_path ||= self.class.template_path
   end
+
   alias_method :path, :template_path
 
   def template_path=(path)
-    @template_path = File.expand_path(path)
+    @template_path = self.class.setup_path(path)
     @template = nil
   end
 
-  # Alias for `template_path`
-  def self.path
-    template_path
-  end
-
-  # Alias for `template_path`
-  def self.path=(path)
-    self.template_path = path
+  class << self
+    alias_method :path, :template_path
+    alias_method :path=, :template_path=
   end
 
 
@@ -104,26 +109,25 @@ class Mustache
   # Template File
   #
 
-  # The template file is the absolute path of the file Mustache will
-  # use as its template. By default it's ./class_name.mustache
+  # The template file is the absolute path of the file Mustache will use as its template.
+  # By default it's ./class_name.mustache
+  #
 
   def self.template_file
-    @template_file || "#{path}/#{template_name}.#{template_extension}"
+    @template_file || path.map{|p| "#{p}/#{template_name}.#{template_extension}" }.find{|tf| File.readable? tf}
   end
 
-  def self.template_file=(template_file)
-    @template_file = template_file
+  def self.template_file=(tf)
+    @template_file = tf
     @template = nil
   end
 
-  # The template file is the absolute path of the file Mustache will
-  # use as its template. By default it's ./class_name.mustache
   def template_file
-    @template_file || "#{path}/#{template_name}.#{template_extension}"
+    @template_file || path.map{|p| "#{p}/#{template_name}.#{template_extension}" }.find{|tf| File.readable? tf}
   end
 
-  def template_file=(template_file)
-    @template_file = template_file
+  def template_file=(tf)
+    @template_file = tf
     @template = nil
   end
 

--- a/test/fixtures/override/passenger.conf
+++ b/test/fixtures/override/passenger.conf
@@ -1,0 +1,6 @@
+<VirtualHost *>
+  ServerAdmin override@mustache.com
+  ServerName {{server}}
+  DocumentRoot {{deploy_to}}
+  RailsEnv {{stage}}
+</VirtualHost>

--- a/test/mustache_test.rb
+++ b/test/mustache_test.rb
@@ -726,14 +726,17 @@ text
     base = Class.new(Mustache)
     tmpl = Class.new(base)
 
-    {:template_path      => File.expand_path('./foo'),
-     :template_extension => 'stache',
+    {:template_extension => 'stache',
      :view_namespace     => TestNamespace,
      :view_path          => './foo'
      }.each do |attr, value|
       base.send("#{attr}=", value)
       assert_equal value, tmpl.send(attr)
     end
+    attr = :template_path
+    value = File.expand_path('./foo')
+    base.send("#{attr}=", value)
+    assert_equal value, tmpl.send(attr).first
   end
 
   def test_hash_default_proc

--- a/test/path_test.rb
+++ b/test/path_test.rb
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+require_relative 'helper'
+
+class MustacheTest < Minitest::Test
+
+  def test_default_path
+    assert_instance_of Array, Mustache.template_path
+    assert_equal 1, Mustache.template_path.size
+    assert_includes Mustache.template_path, Dir.pwd
+  end
+
+  def test_set_multiple_paths
+    old_path = Mustache.template_path
+    Mustache.template_path = "this:that"
+    assert_instance_of Array, Mustache.template_path
+    assert_equal 2, Mustache.template_path.size
+    Mustache.template_path = old_path
+  end
+
+  def test_override_found
+
+    expected = <<-data
+<VirtualHost *>
+  ServerAdmin override@mustache.com
+  ServerName example.com
+  DocumentRoot /var/www/example.com
+  RailsEnv production
+</VirtualHost>
+data
+    old_path = Mustache.template_path
+    old_extension = Mustache.template_extension
+
+    begin
+      base = File.dirname(__FILE__)
+      Mustache.template_extension = "conf"
+      Mustache.template_path = "#{base}/fixtures/override:#{base}/fixtures"
+      assert_equal expected, Mustache.render(:passenger, :stage => 'production',
+                                                         :server => 'example.com',
+                                                         :deploy_to => '/var/www/example.com')
+      Mustache.template_path = "#{base}/fixtures:#{base}/fixtures/override"
+      refute_equal expected, Mustache.render(:passenger, :stage => 'production',
+                                                         :server => 'example.com',
+                                                         :deploy_to => '/var/www/example.com')
+    ensure
+      Mustache.template_path, Mustache.template_extension = old_path, old_extension
+    end
+  end
+
+end

--- a/test/path_test.rb
+++ b/test/path_test.rb
@@ -11,7 +11,7 @@ class MustacheTest < Minitest::Test
 
   def test_set_multiple_paths
     old_path = Mustache.template_path
-    Mustache.template_path = "this:that"
+    Mustache.template_path = "this#{File::PATH_SEPARATOR}that"
     assert_instance_of Array, Mustache.template_path
     assert_equal 2, Mustache.template_path.size
     Mustache.template_path = old_path


### PR DESCRIPTION
The template_path can be a colon-delimited list

This is a resurrection of PR #238 

Closes #238.
Fixes #154.