### PR TITLE
Fix test race condition.

### DIFF
--- a/test/autoloading_test.rb
+++ b/test/autoloading_test.rb
@@ -7,6 +7,10 @@ class AutoloadingTest < Minitest::Test
     Mustache.view_path = File.dirname(__FILE__) + '/fixtures'
   end
 
+  def teardown
+    Mustache.remove_instance_variable(:@view_namespace) if Mustache.instance_variable_defined?(:@view_namespace)
+  end
+
   def test_autoload
     klass = Mustache.view_class(:Comments)
     assert_equal Comments, klass


### PR DESCRIPTION
The test suite randomly fails with errors such as:

~~~
  1) Failure:
AutoloadingTest#test_autoload_lowercase [/builddir/build/BUILD/mustache-1.1.1/usr/share/gems/gems/mustache-1.1.1/test/autoloading_test.rb:17]:
Expected: Comments
  Actual: nil
~~~

This happens when `test_namespaced*` test cases are executed earlier
than the remaining test cases, because they are defining
`view_namespace` but not cleaning up afterwards.