### PR TITLE
Allow methods such as to_a, to_json on hash objects

### DIFF
--- a/lib/mustache/context.rb
+++ b/lib/mustache/context.rb
@@ -160,6 +160,7 @@ class Mustache
       return obj[key]      if obj.has_key?(key)
       return obj[key.to_s] if obj.has_key?(key.to_s)
       return obj[key]      if obj.respond_to?(:default_proc) && obj.default_proc && obj[key]
+      return obj.send(key) if obj.respond_to?(key) # eg. to_a, to_json
 
       # If default is :__missing then we are from #fetch which is hunting through the stack
       # If default is nil then we are reducing dot notation

--- a/test/fixtures/dot_notation.mustache
+++ b/test/fixtures/dot_notation.mustache
@@ -4,6 +4,8 @@
 * {{#person}}{{hometown.city}}, {{hometown.state}}{{/person}}
 * {{#person}}{{#hometown}}{{city}}, {{state}}{{/hometown}}{{/person}}
 * {{#person.hometown}}{{city}}, {{state}}{{/person.hometown}}
+* {{#person}}{{#hometown.to_a}}{{first}}.{{last}};{{/hometown.to_a}}{{/person}}
+* {{#person.hometown.to_a}}{{first}}.{{last}};{{/person.hometown.to_a}}
 * {{normal}}
 
 * {{{person.name.first}}} {{&person.name.last}}

--- a/test/mustache_test.rb
+++ b/test/mustache_test.rb
@@ -714,6 +714,8 @@ text
 * Cincinnati, OH
 * Cincinnati, OH
 * Cincinnati, OH
+* city.Cincinnati;state.OH;
+* city.Cincinnati;state.OH;
 * Normal
 
 * Chris Firescythe


### PR DESCRIPTION
This change makes Hash entries in a context behave more like other object that can have their zero arity methods called on them directly.

Like other objects there is a risk that mutable methods would be called (eg compact!) but this applies to Array already and hash for default_proc (if the default_proc mutates).