### PR TITLE
Update the mustache(5) manpage to the latest specification

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -35,7 +35,7 @@ if command? :ronn
 
   desc "Build the manual"
   task "man:build" do
-    sh "ronn -br5 --organization=DEFUNKT --manual='Mustache Manual' man/*.ronn"
+    sh "ronn -br5 --organization=DEFUNKT --manual='Mustache Manual' man/*.ron"
   end
 end
 

--- a/man/mustache.5
+++ b/man/mustache.5
@@ -191,7 +191,7 @@ Output:
 \fBImplicit Iterator\fR
 .
 .P
-As a special case, if the \fBname\fR consists of only a dot and nothing else, the value that \fBis\fR the current context is interpolated as a whole\. This is especially useful if the parent context is a list; see \fBSections\fR below\.
+As a special case, if the \fBname\fR consists of only a dot and nothing else, the value that is the current context is interpolated as a whole\. This is especially useful if the parent context is a list; see \fBSections\fR below\.
 .
 .P
 Template:

--- a/man/mustache.5
+++ b/man/mustache.5
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "MUSTACHE" "5" "April 2021" "DEFUNKT" "Mustache Manual"
+.TH "MUSTACHE" "5" "May 2021" "DEFUNKT" "Mustache Manual"
 .
 .SH "NAME"
 \fBmustache\fR \- Logic\-less templates\.
@@ -63,7 +63,7 @@ Mustache can be used for HTML, config files, source code \- anything\. It works 
 We call it "logic\-less" because there are no if statements, else clauses, or for loops\. Instead there are only tags\. Some tags are replaced with a value, some nothing, and others a series of values\. This document explains the different types of Mustache tags\.
 .
 .P
-The Mustache language has a formal specification \fIhttps://github\.com/mustache/spec\fR\. The current manpage reflects version 1\.1\.3 of the specification, as well as the de facto established candidate extension for template inheritance \fIhttps://github\.com/mustache/spec/pull/75\fR\.
+The Mustache language has a formal specification \fIhttps://github\.com/mustache/spec\fR\. The current manpage reflects version 1\.2\.1 of the specification, including the official\-but\-optional extensions for lambdas and inheritance\.
 .
 .SH "TAG TYPES"
 Tags are indicated by the double mustaches\. \fB{{person}}\fR is a tag, as is \fB{{#person}}\fR\. In both examples, we\'d refer to \fBperson\fR as the key or tag key\. Let\'s talk about the different types of tags\.
@@ -728,7 +728,7 @@ A block begins with a dollar and ends with a slash\. That is, \fB{{$title}}\fR b
 Blocks mark parts of the template that may be overridden\. This can be done with a block of the same name within a parent section in the calling template (see \fBParents\fR below)\. If not overridden, the contents of a block render just as if the \fB{{$title}}\fR and \fB{{/title}}\fR tags weren\'t there\.
 .
 .P
-Blocks could be thought of as template parameters or as inline partials that may be passed to another template\. They are part of the not\-yet\-official, optional inheritance specification \fIhttps://github\.com/mustache/spec/pull/75\fR\.
+Blocks could be thought of as template parameters or as inline partials that may be passed to another template\. They are part of the optional inheritance extension\.
 .
 .P
 Template \fBarticle\.mustache\fR:

--- a/man/mustache.5
+++ b/man/mustache.5
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "MUSTACHE" "5" "November 2016" "DEFUNKT" "Mustache Manual"
+.TH "MUSTACHE" "5" "April 2021" "DEFUNKT" "Mustache Manual"
 .
 .SH "NAME"
 \fBmustache\fR \- Logic\-less templates\.
@@ -61,6 +61,9 @@ Mustache can be used for HTML, config files, source code \- anything\. It works 
 .
 .P
 We call it "logic\-less" because there are no if statements, else clauses, or for loops\. Instead there are only tags\. Some tags are replaced with a value, some nothing, and others a series of values\. This document explains the different types of Mustache tags\.
+.
+.P
+The Mustache language has a formal specification \fIhttps://github\.com/mustache/spec\fR\. The current manpage reflects version 1\.1\.3 of the specification, as well as the de facto established candidate extension for template inheritance \fIhttps://github\.com/mustache/spec/pull/75\fR\.
 .
 .SH "TAG TYPES"
 Tags are indicated by the double mustaches\. \fB{{person}}\fR is a tag, as is \fB{{#person}}\fR\. In both examples, we\'d refer to \fBperson\fR as the key or tag key\. Let\'s talk about the different types of tags\.
@@ -125,14 +128,185 @@ Output:
 .
 .IP "" 0
 .
+.P
+\fBDotted Names\fR
+.
+.P
+If the \fBname\fR contains dots, it is split on the dots to obtain multiple keys\. The first key is looked up in the context as described above\. If it is found, the next key is looked up within the previous result\. This is repeated until a key is not found or until the last key is found\. The final result is interpolated as above\.
+.
+.P
+Template:
+.
+.IP "" 4
+.
+.nf
+
+* {{client\.name}}
+* {{age}}
+* {{client\.company\.name}}
+* {{{company\.name}}}
+.
+.fi
+.
+.IP "" 0
+.
+.P
+Hash:
+.
+.IP "" 4
+.
+.nf
+
+{
+  "client": {
+    "name": "Chris & Friends",
+    "age": 50
+  },
+  "company": {
+    "name": "<b>GitHub</b>"
+  }
+}
+.
+.fi
+.
+.IP "" 0
+.
+.P
+Output:
+.
+.IP "" 4
+.
+.nf
+
+* Chris &amp; Friends
+*
+*
+* <b>GitHub</b>
+.
+.fi
+.
+.IP "" 0
+.
+.P
+\fBImplicit Iterator\fR
+.
+.P
+As a special case, if the \fBname\fR consists of only a dot and nothing else, the value that \fBis\fR the current context is interpolated as a whole\. This is especially useful if the parent context is a list; see \fBSections\fR below\.
+.
+.P
+Template:
+.
+.IP "" 4
+.
+.nf
+
+* {{\.}}
+.
+.fi
+.
+.IP "" 0
+.
+.P
+Current context:
+.
+.IP "" 4
+.
+.nf
+
+"Hello!"
+.
+.fi
+.
+.IP "" 0
+.
+.P
+Output:
+.
+.IP "" 4
+.
+.nf
+
+* Hello!
+.
+.fi
+.
+.IP "" 0
+.
+.P
+\fBLambdas\fR
+.
+.P
+If any value found during the lookup is a callable object, such as a function or lambda, this object will be invoked with zero arguments\. The value that is returned is then used instead of the callable object itself\.
+.
+.P
+An \fBoptional\fR part of the specification states that if the final key in the \fBname\fR is a lambda that returns a string, then that string should be rendered as a Mustache template before interpolation\. It will be rendered using the default delimiters (see \fBSet Delimiter\fR below) against the current context\.
+.
+.P
+Template:
+.
+.IP "" 4
+.
+.nf
+
+* {{time\.hour}}
+* {{today}}
+.
+.fi
+.
+.IP "" 0
+.
+.P
+Hash:
+.
+.IP "" 4
+.
+.nf
+
+{
+  "year": 1970,
+  "month": 1,
+  "day": 1,
+  "time": function() {
+    return {
+      "hour": 0,
+      "minute": 0,
+      "second": 0
+    }
+  },
+  "today": function() {
+    return "{{year}}\-{{month}}\-{{day}}"
+  }
+}
+.
+.fi
+.
+.IP "" 0
+.
+.P
+Output:
+.
+.IP "" 4
+.
+.nf
+
+* 0
+* 1970\-1\-1
+.
+.fi
+.
+.IP "" 0
+.
 .SS "Sections"
 Sections render blocks of text zero or more times, depending on the value of the key in the current context\.
+.
+.P
+Lookup of dotted names works in the same way as with variables, except for slightly different treatment of lambdas\. More on this below\.
 .
 .P
 A section begins with a pound and ends with a slash\. That is, \fB{{#person}}\fR begins a "person" section while \fB{{/person}}\fR ends it\.
 .
 .P
-The behavior of the section is determined by the value of the key\.
+The behavior of the section is determined by the final value of the key lookup\.
 .
 .P
 \fBFalse Values or Empty Lists\fR
@@ -234,9 +408,57 @@ Output:
 .
 .nf
 
-<b>resque</b>
-<b>hub</b>
-<b>rip</b>
+  <b>resque</b>
+  <b>hub</b>
+  <b>rip</b>
+.
+.fi
+.
+.IP "" 0
+.
+.P
+The same effect as above can be obtained without nested objects, by using the implicit iterator (see \fBVariables\fR above)\.
+.
+.P
+Template:
+.
+.IP "" 4
+.
+.nf
+
+{{#repo}}
+  <b>{{\.}}</b>
+{{/repo}}
+.
+.fi
+.
+.IP "" 0
+.
+.P
+Hash:
+.
+.IP "" 4
+.
+.nf
+
+{
+  "repo": ["resque", "hub", "rip"]
+}
+.
+.fi
+.
+.IP "" 0
+.
+.P
+Output:
+.
+.IP "" 4
+.
+.nf
+
+  <b>resque</b>
+  <b>hub</b>
+  <b>rip</b>
 .
 .fi
 .
@@ -246,7 +468,10 @@ Output:
 \fBLambdas\fR
 .
 .P
-When the value is a callable object, such as a function or lambda, the object will be invoked and passed the block of text\. The text passed is the literal block, unrendered\. \fB{{tags}}\fR will not have been expanded \- the lambda should do that on its own\. In this way you can implement filters or caching\.
+When any value found during the lookup is a callable object, such as a function or lambda, the object will be invoked and passed the block of text\. The text passed is the literal block, unrendered\. \fB{{tags}}\fR will not have been expanded\.
+.
+.P
+An \fBoptional\fR part of the specification states that if the final key in the \fBname\fR is a lambda that returns a string, then that string replaces the content of the section\. It will be rendered using the same delimiters (see \fBSet Delimiter\fR below) as the original section content\. In this way you can implement filters or caching\.
 .
 .P
 Template:
@@ -255,9 +480,7 @@ Template:
 .
 .nf
 
-{{#wrapped}}
-  {{name}} is awesome\.
-{{/wrapped}}
+{{#wrapped}}{{name}} is awesome\.{{/wrapped}}
 .
 .fi
 .
@@ -272,10 +495,8 @@ Hash:
 
 {
   "name": "Willy",
-  "wrapped": function() {
-    return function(text, render) {
-      return "<b>" + render(text) + "</b>"
-    }
+  "wrapped": function(text) {
+    return "<b>" + text + "</b>"
   }
 }
 .
@@ -339,7 +560,7 @@ Output:
 .
 .nf
 
-Hi Jon!
+  Hi Jon!
 .
 .fi
 .
@@ -391,7 +612,7 @@ Output:
 .
 .nf
 
-No repos :(
+  No repos :(
 .
 .fi
 .
@@ -500,6 +721,114 @@ Can be thought of as a single, expanded template:
 .
 .IP "" 0
 .
+.SS "Blocks"
+A block begins with a dollar and ends with a slash\. That is, \fB{{$title}}\fR begins a "title" block and \fB{{/title}}\fR ends it\.
+.
+.P
+Blocks mark parts of the template that may be overridden\. This can be done with a block of the same name within a parent section in the calling template (see \fBParents\fR below)\. If not overridden, the contents of a block render just as if the \fB{{$title}}\fR and \fB{{/title}}\fR tags weren\'t there\.
+.
+.P
+Blocks could be thought of as template parameters or as inline partials that may be passed to another template\. They are part of the not\-yet\-official, optional inheritance specification \fIhttps://github\.com/mustache/spec/pull/75\fR\.
+.
+.P
+Template \fBarticle\.mustache\fR:
+.
+.IP "" 4
+.
+.nf
+
+<h1>{{$title}}The News of Today{{/title}}</h1>
+{{$body}}
+<p>Nothing special happened\.</p>
+{{/body}}
+.
+.fi
+.
+.IP "" 0
+.
+.P
+Output:
+.
+.IP "" 4
+.
+.nf
+
+<h1>The News of Today</h1>
+<p>Nothing special happened\.</p>
+.
+.fi
+.
+.IP "" 0
+.
+.SS "Parents"
+A parent begins with a less than sign and ends with a slash\. That is, \fB{{<article}}\fR begins an "article" parent and \fB{{/article}}\fR ends it\.
+.
+.P
+Like an \fB{{>article}}\fR partial, a parent lets you expand another template inside the current one\. Unlike a partial, a parent also lets you override blocks of the other template\.
+.
+.P
+Blocks within a parent can again be overridden by another including template\. Other content within a parent is ignored, like comments\.
+.
+.P
+Template:
+.
+.IP "" 4
+.
+.nf
+
+{{<article}}
+  Never shown
+  {{$body}}
+    {{#headlines}}
+    <p>{{\.}}</p>
+    {{/headlines}}
+  {{/body}}
+{{/article}}
+
+{{<article}}
+  {{$title}}Yesterday{{/title}}
+{{/article}}
+.
+.fi
+.
+.IP "" 0
+.
+.P
+Hash:
+.
+.IP "" 4
+.
+.nf
+
+{
+  "headlines": [
+    "A pug\'s handler grew mustaches\.",
+    "What an exciting day!"
+  ]
+}
+.
+.fi
+.
+.IP "" 0
+.
+.P
+Output, assuming the \fBarticle\.mustache\fR from before:
+.
+.IP "" 4
+.
+.nf
+
+<h1>The News of Today</h1>
+<p>A pug\'s handler grew mustaches\.</p>
+<p>What an exciting day!</p>
+
+<h1>Yesterday</h1>
+<p>Nothing special happened\.</p>
+.
+.fi
+.
+.IP "" 0
+.
 .SS "Set Delimiter"
 Set Delimiter tags start with an equal sign and change the tag delimiters from \fB{{\fR and \fB}}\fR to custom strings\.
 .
@@ -524,7 +853,7 @@ Consider the following contrived example:
 Here we have a list with three items\. The first item uses the default tag style, the second uses erb style as defined by the Set Delimiter tag, and the third returns to the default style after yet another Set Delimiter declaration\.
 .
 .P
-According to ctemplates \fIhttp://google\-ctemplate\.googlecode\.com/svn/trunk/doc/howto\.html\fR, this "is useful for languages like TeX, where double\-braces may occur in the text and are awkward to use for markup\."
+According to ctemplates \fIhttp://goog\-ctemplate\.sourceforge\.net/doc/howto\.html\fR, this "is useful for languages like TeX, where double\-braces may occur in the text and are awkward to use for markup\."
 .
 .P
 Custom delimiters may not contain whitespace or the equals sign\.

--- a/man/mustache.5
+++ b/man/mustache.5
@@ -1,162 +1,104 @@
-.\" generated with Ronn/v0.7.3
-.\" http://github.com/rtomayko/ronn/tree/0.7.3
-.
-.TH "MUSTACHE" "5" "May 2021" "DEFUNKT" "Mustache Manual"
-.
+.\" generated with Ronn-NG/v0.9.1
+.\" http://github.com/apjanke/ronn-ng/tree/0.9.1
+.TH "MUSTACHE" "5" "September 2022" "DEFUNKT" "Mustache Manual"
 .SH "NAME"
 \fBmustache\fR \- Logic\-less templates\.
-.
 .SH "SYNOPSIS"
 A typical Mustache template:
-.
 .IP "" 4
-.
 .nf
-
 Hello {{name}}
 You have just won {{value}} dollars!
 {{#in_ca}}
 Well, {{taxed_value}} dollars, after taxes\.
 {{/in_ca}}
-.
 .fi
-.
 .IP "" 0
-.
 .P
 Given the following hash:
-.
 .IP "" 4
-.
 .nf
-
 {
   "name": "Chris",
   "value": 10000,
   "taxed_value": 10000 \- (10000 * 0\.4),
   "in_ca": true
 }
-.
 .fi
-.
 .IP "" 0
-.
 .P
 Will produce the following:
-.
 .IP "" 4
-.
 .nf
-
 Hello Chris
 You have just won 10000 dollars!
 Well, 6000\.0 dollars, after taxes\.
-.
 .fi
-.
 .IP "" 0
-.
 .SH "DESCRIPTION"
 Mustache can be used for HTML, config files, source code \- anything\. It works by expanding tags in a template using values provided in a hash or object\.
-.
 .P
 We call it "logic\-less" because there are no if statements, else clauses, or for loops\. Instead there are only tags\. Some tags are replaced with a value, some nothing, and others a series of values\. This document explains the different types of Mustache tags\.
-.
 .P
-The Mustache language has a formal specification \fIhttps://github\.com/mustache/spec\fR\. The current manpage reflects version 1\.2\.1 of the specification, including the official\-but\-optional extensions for lambdas and inheritance\.
-.
+The Mustache language has a formal specification \fIhttps://github\.com/mustache/spec\fR\. The current manpage reflects version 1\.3\.0 of the specification, including the official\-but\-optional extensions for lambdas and inheritance\.
 .SH "TAG TYPES"
-Tags are indicated by the double mustaches\. \fB{{person}}\fR is a tag, as is \fB{{#person}}\fR\. In both examples, we\'d refer to \fBperson\fR as the key or tag key\. Let\'s talk about the different types of tags\.
-.
+Tags are indicated by the double mustaches\. \fB{{person}}\fR is a tag, as is \fB{{#person}}\fR\. In both examples, we'd refer to \fBperson\fR as the key or tag key\. Let's talk about the different types of tags\.
 .SS "Variables"
 The most basic tag type is the variable\. A \fB{{name}}\fR tag in a basic template will try to find the \fBname\fR key in the current context\. If there is no \fBname\fR key, the parent contexts will be checked recursively\. If the top context is reached and the \fBname\fR key is still not found, nothing will be rendered\.
-.
 .P
 All variables are HTML escaped by default\. If you want to return raw contents without escaping, use the triple mustache: \fB{{{name}}}\fR\.
-.
 .P
 You can also use \fB&\fR to return its raw contents: \fB{{& name}}\fR\. This may be useful when changing delimiters (see "Set Delimiter" below)\.
-.
 .P
 By default a variable "miss" returns an empty string\. This can usually be configured in your Mustache library\. The Ruby version of Mustache supports raising an exception in this situation, for instance\.
-.
 .P
 Template:
-.
 .IP "" 4
-.
 .nf
-
 * {{name}}
 * {{age}}
 * {{company}}
 * {{{company}}}
-.
 .fi
-.
 .IP "" 0
-.
 .P
 Hash:
-.
 .IP "" 4
-.
 .nf
-
 {
   "name": "Chris",
   "company": "<b>GitHub</b>"
 }
-.
 .fi
-.
 .IP "" 0
-.
 .P
 Output:
-.
 .IP "" 4
-.
 .nf
-
 * Chris
 *
 * &lt;b&gt;GitHub&lt;/b&gt;
 * <b>GitHub</b>
-.
 .fi
-.
 .IP "" 0
-.
 .P
 \fBDotted Names\fR
-.
 .P
 If the \fBname\fR contains dots, it is split on the dots to obtain multiple keys\. The first key is looked up in the context as described above\. If it is found, the next key is looked up within the previous result\. This is repeated until a key is not found or until the last key is found\. The final result is interpolated as above\.
-.
 .P
 Template:
-.
 .IP "" 4
-.
 .nf
-
 * {{client\.name}}
 * {{age}}
 * {{client\.company\.name}}
 * {{{company\.name}}}
-.
 .fi
-.
 .IP "" 0
-.
 .P
 Hash:
-.
 .IP "" 4
-.
 .nf
-
 {
   "client": {
     "name": "Chris & Friends",
@@ -166,102 +108,61 @@ Hash:
     "name": "<b>GitHub</b>"
   }
 }
-.
 .fi
-.
 .IP "" 0
-.
 .P
 Output:
-.
 .IP "" 4
-.
 .nf
-
 * Chris &amp; Friends
 *
 *
 * <b>GitHub</b>
-.
 .fi
-.
 .IP "" 0
-.
 .P
 \fBImplicit Iterator\fR
-.
 .P
 As a special case, if the \fBname\fR consists of only a dot and nothing else, the value that is the current context is interpolated as a whole\. This is especially useful if the parent context is a list; see \fBSections\fR below\.
-.
 .P
 Template:
-.
 .IP "" 4
-.
 .nf
-
 * {{\.}}
-.
 .fi
-.
 .IP "" 0
-.
 .P
 Current context:
-.
 .IP "" 4
-.
 .nf
-
 "Hello!"
-.
 .fi
-.
 .IP "" 0
-.
 .P
 Output:
-.
 .IP "" 4
-.
 .nf
-
 * Hello!
-.
 .fi
-.
 .IP "" 0
-.
 .P
 \fBLambdas\fR
-.
 .P
 If any value found during the lookup is a callable object, such as a function or lambda, this object will be invoked with zero arguments\. The value that is returned is then used instead of the callable object itself\.
-.
 .P
 An \fBoptional\fR part of the specification states that if the final key in the \fBname\fR is a lambda that returns a string, then that string should be rendered as a Mustache template before interpolation\. It will be rendered using the default delimiters (see \fBSet Delimiter\fR below) against the current context\.
-.
 .P
 Template:
-.
 .IP "" 4
-.
 .nf
-
 * {{time\.hour}}
 * {{today}}
-.
 .fi
-.
 .IP "" 0
-.
 .P
 Hash:
-.
 .IP "" 4
-.
 .nf
-
 {
   "year": 1970,
   "month": 1,
@@ -277,118 +178,73 @@ Hash:
     return "{{year}}\-{{month}}\-{{day}}"
   }
 }
-.
 .fi
-.
 .IP "" 0
-.
 .P
 Output:
-.
 .IP "" 4
-.
 .nf
-
 * 0
 * 1970\-1\-1
-.
 .fi
-.
 .IP "" 0
-.
 .SS "Sections"
 Sections render blocks of text zero or more times, depending on the value of the key in the current context\.
-.
 .P
 Lookup of dotted names works in the same way as with variables, except for slightly different treatment of lambdas\. More on this below\.
-.
 .P
 A section begins with a pound and ends with a slash\. That is, \fB{{#person}}\fR begins a "person" section while \fB{{/person}}\fR ends it\.
-.
 .P
 The behavior of the section is determined by the final value of the key lookup\.
-.
 .P
 \fBFalse Values or Empty Lists\fR
-.
 .P
 If the \fBperson\fR key exists and has a value of false or an empty list, the HTML between the pound and slash will not be displayed\.
-.
 .P
 Template:
-.
 .IP "" 4
-.
 .nf
-
 Shown\.
 {{#person}}
   Never shown!
 {{/person}}
-.
 .fi
-.
 .IP "" 0
-.
 .P
 Hash:
-.
 .IP "" 4
-.
 .nf
-
 {
   "person": false
 }
-.
 .fi
-.
 .IP "" 0
-.
 .P
 Output:
-.
 .IP "" 4
-.
 .nf
-
 Shown\.
-.
 .fi
-.
 .IP "" 0
-.
 .P
 \fBNon\-Empty Lists\fR
-.
 .P
 If the \fBperson\fR key exists and has a non\-false value, the HTML between the pound and slash will be rendered and displayed one or more times\.
-.
 .P
 When the value is a non\-empty list, the text in the block will be displayed once for each item in the list\. The context of the block will be set to the current item for each iteration\. In this way we can loop over collections\.
-.
 .P
 Template:
-.
 .IP "" 4
-.
 .nf
-
 {{#repo}}
   <b>{{name}}</b>
 {{/repo}}
-.
 .fi
-.
 .IP "" 0
-.
 .P
 Hash:
-.
 .IP "" 4
-.
 .nf
-
 {
   "repo": [
     { "name": "resque" },
@@ -396,302 +252,181 @@ Hash:
     { "name": "rip" }
   ]
 }
-.
 .fi
-.
 .IP "" 0
-.
 .P
 Output:
-.
 .IP "" 4
-.
 .nf
-
   <b>resque</b>
   <b>hub</b>
   <b>rip</b>
-.
 .fi
-.
 .IP "" 0
-.
 .P
 The same effect as above can be obtained without nested objects, by using the implicit iterator (see \fBVariables\fR above)\.
-.
 .P
 Template:
-.
 .IP "" 4
-.
 .nf
-
 {{#repo}}
   <b>{{\.}}</b>
 {{/repo}}
-.
 .fi
-.
 .IP "" 0
-.
 .P
 Hash:
-.
 .IP "" 4
-.
 .nf
-
 {
   "repo": ["resque", "hub", "rip"]
 }
-.
 .fi
-.
 .IP "" 0
-.
 .P
 Output:
-.
 .IP "" 4
-.
 .nf
-
   <b>resque</b>
   <b>hub</b>
   <b>rip</b>
-.
 .fi
-.
 .IP "" 0
-.
 .P
 \fBLambdas\fR
-.
 .P
 When any value found during the lookup is a callable object, such as a function or lambda, the object will be invoked and passed the block of text\. The text passed is the literal block, unrendered\. \fB{{tags}}\fR will not have been expanded\.
-.
 .P
 An \fBoptional\fR part of the specification states that if the final key in the \fBname\fR is a lambda that returns a string, then that string replaces the content of the section\. It will be rendered using the same delimiters (see \fBSet Delimiter\fR below) as the original section content\. In this way you can implement filters or caching\.
-.
 .P
 Template:
-.
 .IP "" 4
-.
 .nf
-
 {{#wrapped}}{{name}} is awesome\.{{/wrapped}}
-.
 .fi
-.
 .IP "" 0
-.
 .P
 Hash:
-.
 .IP "" 4
-.
 .nf
-
 {
   "name": "Willy",
   "wrapped": function(text) {
     return "<b>" + text + "</b>"
   }
 }
-.
 .fi
-.
 .IP "" 0
-.
 .P
 Output:
-.
 .IP "" 4
-.
 .nf
-
 <b>Willy is awesome\.</b>
-.
 .fi
-.
 .IP "" 0
-.
 .P
 \fBNon\-False Values\fR
-.
 .P
 When the value is non\-false but not a list, it will be used as the context for a single rendering of the block\.
-.
 .P
 Template:
-.
 .IP "" 4
-.
 .nf
-
 {{#person?}}
   Hi {{name}}!
 {{/person?}}
-.
 .fi
-.
 .IP "" 0
-.
 .P
 Hash:
-.
 .IP "" 4
-.
 .nf
-
 {
   "person?": { "name": "Jon" }
 }
-.
 .fi
-.
 .IP "" 0
-.
 .P
 Output:
-.
 .IP "" 4
-.
 .nf
-
   Hi Jon!
-.
 .fi
-.
 .IP "" 0
-.
 .SS "Inverted Sections"
 An inverted section begins with a caret (hat) and ends with a slash\. That is \fB{{^person}}\fR begins a "person" inverted section while \fB{{/person}}\fR ends it\.
-.
 .P
-While sections can be used to render text zero or more times based on the value of the key, inverted sections may render text once based on the inverse value of the key\. That is, they will be rendered if the key doesn\'t exist, is false, or is an empty list\.
-.
+While sections can be used to render text zero or more times based on the value of the key, inverted sections may render text once based on the inverse value of the key\. That is, they will be rendered if the key doesn't exist, is false, or is an empty list\.
 .P
 Template:
-.
 .IP "" 4
-.
 .nf
-
 {{#repo}}
   <b>{{name}}</b>
 {{/repo}}
 {{^repo}}
   No repos :(
 {{/repo}}
-.
 .fi
-.
 .IP "" 0
-.
 .P
 Hash:
-.
 .IP "" 4
-.
 .nf
-
 {
   "repo": []
 }
-.
 .fi
-.
 .IP "" 0
-.
 .P
 Output:
-.
 .IP "" 4
-.
 .nf
-
   No repos :(
-.
 .fi
-.
 .IP "" 0
-.
 .SS "Comments"
 Comments begin with a bang and are ignored\. The following template:
-.
 .IP "" 4
-.
 .nf
-
 <h1>Today{{! ignore me }}\.</h1>
-.
 .fi
-.
 .IP "" 0
-.
 .P
 Will render as follows:
-.
 .IP "" 4
-.
 .nf
-
 <h1>Today\.</h1>
-.
 .fi
-.
 .IP "" 0
-.
 .P
 Comments may contain newlines\.
-.
 .SS "Partials"
 Partials begin with a greater than sign, like \fB{{> box}}\fR\.
-.
 .P
 Partials are rendered at runtime (as opposed to compile time), so recursive partials are possible\. Just avoid infinite loops\.
-.
 .P
 They also inherit the calling context\. Whereas in ERB you may have this:
-.
 .IP "" 4
-.
 .nf
-
 <%= partial :next_more, :start => start, :size => size %>
-.
 .fi
-.
 .IP "" 0
-.
 .P
 Mustache requires only this:
-.
 .IP "" 4
-.
 .nf
-
 {{> next_more}}
-.
 .fi
-.
 .IP "" 0
-.
 .P
 Why? Because the \fBnext_more\.mustache\fR file will inherit the \fBsize\fR and \fBstart\fR methods from the calling context\.
-.
 .P
-In this way you may want to think of partials as includes, or template expansion, even though it\'s not literally true\.
-.
+In this way you may want to think of partials as includes, or template expansion, even though it's not literally true\.
 .P
 For example, this template and partial:
-.
 .IP "" 4
-.
 .nf
-
 base\.mustache:
 <h2>Names</h2>
 {{#names}}
@@ -700,82 +435,85 @@ base\.mustache:
 
 user\.mustache:
 <strong>{{name}}</strong>
-.
 .fi
-.
 .IP "" 0
-.
 .P
 Can be thought of as a single, expanded template:
-.
 .IP "" 4
-.
 .nf
-
 <h2>Names</h2>
 {{#names}}
   <strong>{{name}}</strong>
 {{/names}}
-.
 .fi
-.
 .IP "" 0
-.
+.P
+\fBDynamic Names\fR
+.P
+Partials can be loaded dynamically at runtime using Dynamic Names; an \fBoptional\fR part of the Mustache specification which allows to dynamically determine a tag's content at runtime\.
+.P
+Dynamic Names consists of an asterisk, followed by a dotted name which follows the same notation and the same resolution as in an variable tag\. That is \fB{{>*dynamic}}\fR\. It can be thought as the following \fBhypothetical\fR tag (which is \fBnot allowed\fR!): \fB{{>{{dynamic}}}}\fR\.
+.P
+Templates:
+.IP "" 4
+.nf
+main\.mustache:
+Hello {{>*dynamic}}
+
+world\.template:
+everyone!
+.fi
+.IP "" 0
+.P
+Hash:
+.IP "" 4
+.nf
+{
+  "dynamic": "world"
+}
+.fi
+.IP "" 0
+.P
+Output:
+.IP "" 4
+.nf
+Hello everyone!
+.fi
+.IP "" 0
 .SS "Blocks"
 A block begins with a dollar and ends with a slash\. That is, \fB{{$title}}\fR begins a "title" block and \fB{{/title}}\fR ends it\.
-.
 .P
-Blocks mark parts of the template that may be overridden\. This can be done with a block of the same name within a parent section in the calling template (see \fBParents\fR below)\. If not overridden, the contents of a block render just as if the \fB{{$title}}\fR and \fB{{/title}}\fR tags weren\'t there\.
-.
+Blocks mark parts of the template that may be overridden\. This can be done with a block of the same name within a parent section in the calling template (see \fBParents\fR below)\. If not overridden, the contents of a block render just as if the \fB{{$title}}\fR and \fB{{/title}}\fR tags weren't there\.
 .P
 Blocks could be thought of as template parameters or as inline partials that may be passed to another template\. They are part of the optional inheritance extension\.
-.
 .P
 Template \fBarticle\.mustache\fR:
-.
 .IP "" 4
-.
 .nf
-
 <h1>{{$title}}The News of Today{{/title}}</h1>
 {{$body}}
 <p>Nothing special happened\.</p>
 {{/body}}
-.
 .fi
-.
 .IP "" 0
-.
 .P
 Output:
-.
 .IP "" 4
-.
 .nf
-
 <h1>The News of Today</h1>
 <p>Nothing special happened\.</p>
-.
 .fi
-.
 .IP "" 0
-.
 .SS "Parents"
 A parent begins with a less than sign and ends with a slash\. That is, \fB{{<article}}\fR begins an "article" parent and \fB{{/article}}\fR ends it\.
-.
 .P
 Like an \fB{{>article}}\fR partial, a parent lets you expand another template inside the current one\. Unlike a partial, a parent also lets you override blocks of the other template\.
-.
 .P
 Blocks within a parent can again be overridden by another including template\. Other content within a parent is ignored, like comments\.
-.
 .P
 Template:
-.
 .IP "" 4
-.
 .nf
-
 {{<article}}
   Never shown
   {{$body}}
@@ -788,81 +526,90 @@ Template:
 {{<article}}
   {{$title}}Yesterday{{/title}}
 {{/article}}
-.
 .fi
-.
 .IP "" 0
-.
 .P
 Hash:
-.
 .IP "" 4
-.
 .nf
-
 {
   "headlines": [
-    "A pug\'s handler grew mustaches\.",
+    "A pug's handler grew mustaches\.",
     "What an exciting day!"
   ]
 }
-.
 .fi
-.
 .IP "" 0
-.
 .P
 Output, assuming the \fBarticle\.mustache\fR from before:
-.
 .IP "" 4
-.
 .nf
-
 <h1>The News of Today</h1>
-<p>A pug\'s handler grew mustaches\.</p>
+<p>A pug's handler grew mustaches\.</p>
 <p>What an exciting day!</p>
 
 <h1>Yesterday</h1>
 <p>Nothing special happened\.</p>
-.
 .fi
-.
 .IP "" 0
-.
+.P
+\fBDynamic Names\fR
+.P
+Some mustache implementations may allow the use of Dynamic Names in parent tags, similar to dynamic names in partials\. Here's an example of how Dynamic Names in parent tags work\.
+.P
+Templates:
+.IP "" 4
+.nf
+{{!normal\.mustache}}
+{{$text}}Here goes nothing\.{{/text}}
+
+{{!bold\.mustache}}
+<b>{{$text}}Here also goes nothing but it's bold\.{{/text}}</b>
+
+{{!dynamic\.mustache}}
+{{<*dynamic}}
+  {{$text}}Hello World!{{/text}}
+{{/*dynamic}}
+.fi
+.IP "" 0
+.P
+Hash:
+.IP "" 4
+.nf
+{
+  "dynamic": "bold"
+}
+.fi
+.IP "" 0
+.P
+Output:
+.IP "" 4
+.nf
+<b>Hello World!</b>
+.fi
+.IP "" 0
 .SS "Set Delimiter"
 Set Delimiter tags start with an equal sign and change the tag delimiters from \fB{{\fR and \fB}}\fR to custom strings\.
-.
 .P
 Consider the following contrived example:
-.
 .IP "" 4
-.
 .nf
-
 * {{default_tags}}
 {{=<% %>=}}
 * <% erb_style_tags %>
 <%={{ }}=%>
 * {{ default_tags_again }}
-.
 .fi
-.
 .IP "" 0
-.
 .P
 Here we have a list with three items\. The first item uses the default tag style, the second uses erb style as defined by the Set Delimiter tag, and the third returns to the default style after yet another Set Delimiter declaration\.
-.
 .P
 According to ctemplates \fIhttp://goog\-ctemplate\.sourceforge\.net/doc/howto\.html\fR, this "is useful for languages like TeX, where double\-braces may occur in the text and are awkward to use for markup\."
-.
 .P
 Custom delimiters may not contain whitespace or the equals sign\.
-.
 .SH "COPYRIGHT"
 Mustache is Copyright (C) 2009 Chris Wanstrath
-.
 .P
 Original CTemplate by Google
-.
 .SH "SEE ALSO"
 mustache(1), \fIhttp://mustache\.github\.io/\fR

--- a/man/mustache.5.html
+++ b/man/mustache.5.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <meta http-equiv='content-type' value='text/html;charset=utf8'>
-  <meta name='generator' value='Ronn/v0.7.3 (http://github.com/rtomayko/ronn/tree/0.7.3)'>
+  <meta http-equiv='content-type' content='text/html;charset=utf8'>
+  <meta name='generator' content='Ronn-NG/v0.9.1 (http://github.com/apjanke/ronn-ng/tree/0.9.1)'>
   <title>mustache(5) - Logic-less templates.</title>
   <style type='text/css' media='all'>
   /* style: man */
@@ -67,11 +67,12 @@
     <li class='tr'>mustache(5)</li>
   </ol>
 
-  <h2 id="NAME">NAME</h2>
+  
+
+<h2 id="NAME">NAME</h2>
 <p class="man-name">
   <code>mustache</code> - <span class="man-whatis">Logic-less templates.</span>
 </p>
-
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
 <p>A typical Mustache template:</p>
@@ -112,7 +113,7 @@ replaced with a value, some nothing, and others a series of
 values. This document explains the different types of Mustache tags.</p>
 
 <p>The Mustache language has a <a href="https://github.com/mustache/spec">formal specification</a>. The current
-manpage reflects version 1.2.1 of the specification, including the
+manpage reflects version 1.3.0 of the specification, including the
 official-but-optional extensions for lambdas and inheritance.</p>
 
 <h2 id="TAG-TYPES">TAG TYPES</h2>
@@ -511,6 +512,38 @@ user.mustache:
 {{/names}}
 </code></pre>
 
+<p><strong>Dynamic Names</strong></p>
+
+<p>Partials can be loaded dynamically at runtime using Dynamic Names; an
+<strong>optional</strong> part of the Mustache specification which allows to dynamically
+determine a tag's content at runtime.</p>
+
+<p>Dynamic Names consists of an asterisk, followed by a dotted name which follows
+the same notation and the same resolution as in an variable tag. That is
+<code>{{&gt;*dynamic}}</code>. It can be thought as the following <strong>hypothetical</strong> tag
+(which is <strong>not allowed</strong>!): <code>{{&gt;{{dynamic}}}}</code>.</p>
+
+<p>Templates:</p>
+
+<pre><code>main.mustache:
+Hello {{&gt;*dynamic}}
+
+world.template:
+everyone!
+</code></pre>
+
+<p>Hash:</p>
+
+<pre><code>{
+  "dynamic": "world"
+}
+</code></pre>
+
+<p>Output:</p>
+
+<pre><code>Hello everyone!
+</code></pre>
+
 <h3 id="Blocks">Blocks</h3>
 
 <p>A block begins with a dollar and ends with a slash. That is, <code>{{$title}}</code>
@@ -558,7 +591,7 @@ template. Other content within a parent is ignored, like comments.</p>
   Never shown
   {{$body}}
     {{#headlines}}
-    &lt;p>{{.}}&lt;/p&gt;
+    &lt;p&gt;{{.}}&lt;/p&gt;
     {{/headlines}}
   {{/body}}
 {{/article}}
@@ -588,6 +621,38 @@ template. Other content within a parent is ignored, like comments.</p>
 &lt;p&gt;Nothing special happened.&lt;/p&gt;
 </code></pre>
 
+<p><strong>Dynamic Names</strong></p>
+
+<p>Some mustache implementations may allow the use of Dynamic Names in
+parent tags, similar to dynamic names in partials. Here's an example of
+how Dynamic Names in parent tags work.</p>
+
+<p>Templates:</p>
+
+<pre><code>{{!normal.mustache}}
+{{$text}}Here goes nothing.{{/text}}
+
+{{!bold.mustache}}
+&lt;b&gt;{{$text}}Here also goes nothing but it's bold.{{/text}}&lt;/b&gt;
+
+{{!dynamic.mustache}}
+{{&lt;*dynamic}}
+  {{$text}}Hello World!{{/text}}
+{{/*dynamic}}
+</code></pre>
+
+<p>Hash:</p>
+
+<pre><code>{
+  "dynamic": "bold"
+}
+</code></pre>
+
+<p>Output:</p>
+
+<pre><code>&lt;b&gt;Hello World!&lt;/b&gt;
+</code></pre>
+
 <h3 id="Set-Delimiter">Set Delimiter</h3>
 
 <p>Set Delimiter tags start with an equal sign and change the tag
@@ -596,9 +661,9 @@ delimiters from <code>{{</code> and <code>}}</code> to custom strings.</p>
 <p>Consider the following contrived example:</p>
 
 <pre><code>* {{default_tags}}
-{{=&lt;% %>=}}
-* &lt;% erb_style_tags %>
-&lt;%={{ }}=%>
+{{=&lt;% %&gt;=}}
+* &lt;% erb_style_tags %&gt;
+&lt;%={{ }}=%&gt;
 * {{ default_tags_again }}
 </code></pre>
 
@@ -624,10 +689,9 @@ markup."</p>
 <p><a class="man-ref" href="mustache.1.ron.html">mustache<span class="s">(1)</span></a>,
 <a href="http://mustache.github.io/" data-bare-link="true">http://mustache.github.io/</a></p>
 
-
   <ol class='man-decor man-foot man foot'>
     <li class='tl'>DEFUNKT</li>
-    <li class='tc'>May 2021</li>
+    <li class='tc'>September 2022</li>
     <li class='tr'>mustache(5)</li>
   </ol>
 

--- a/man/mustache.5.html
+++ b/man/mustache.5.html
@@ -111,9 +111,9 @@ clauses, or for loops. Instead there are only tags. Some tags are
 replaced with a value, some nothing, and others a series of
 values. This document explains the different types of Mustache tags.</p>
 
-<p>The Mustache language has a <a href="https://github.com/mustache/spec">formal specification</a>. The current manpage
-reflects version 1.1.3 of the specification, as well as the de facto
-established <a href="https://github.com/mustache/spec/pull/75">candidate extension for template inheritance</a>.</p>
+<p>The Mustache language has a <a href="https://github.com/mustache/spec">formal specification</a>. The current
+manpage reflects version 1.2.1 of the specification, including the
+official-but-optional extensions for lambdas and inheritance.</p>
 
 <h2 id="TAG-TYPES">TAG TYPES</h2>
 
@@ -523,8 +523,8 @@ block render just as if the <code>{{$title}}</code> and <code>{{/title}}</code> 
 there.</p>
 
 <p>Blocks could be thought of as template parameters or as inline partials
-that may be passed to another template. They are part of the
-not-yet-official, optional <a href="https://github.com/mustache/spec/pull/75">inheritance specification</a>.</p>
+that may be passed to another template. They are part of the optional
+inheritance extension.</p>
 
 <p>Template <code>article.mustache</code>:</p>
 
@@ -627,7 +627,7 @@ markup."</p>
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'>DEFUNKT</li>
-    <li class='tc'>April 2021</li>
+    <li class='tc'>May 2021</li>
     <li class='tr'>mustache(5)</li>
   </ol>
 

--- a/man/mustache.5.html
+++ b/man/mustache.5.html
@@ -203,7 +203,7 @@ final result is interpolated as above.</p>
 <p><strong>Implicit Iterator</strong></p>
 
 <p>As a special case, if the <code>name</code> consists of only a dot and nothing else,
-the value that <strong>is</strong> the current context is interpolated as a whole. This
+the value that is the current context is interpolated as a whole. This
 is especially useful if the parent context is a list; see <strong>Sections</strong>
 below.</p>
 

--- a/man/mustache.5.html
+++ b/man/mustache.5.html
@@ -111,6 +111,10 @@ clauses, or for loops. Instead there are only tags. Some tags are
 replaced with a value, some nothing, and others a series of
 values. This document explains the different types of Mustache tags.</p>
 
+<p>The Mustache language has a <a href="https://github.com/mustache/spec">formal specification</a>. The current manpage
+reflects version 1.1.3 of the specification, as well as the de facto
+established <a href="https://github.com/mustache/spec/pull/75">candidate extension for template inheritance</a>.</p>
+
 <h2 id="TAG-TYPES">TAG TYPES</h2>
 
 <p>Tags are indicated by the double mustaches. <code>{{person}}</code> is a tag, as
@@ -159,15 +163,121 @@ supports raising an exception in this situation, for instance.</p>
 * &lt;b&gt;GitHub&lt;/b&gt;
 </code></pre>
 
+<p><strong>Dotted Names</strong></p>
+
+<p>If the <code>name</code> contains dots, it is split on the dots to obtain multiple
+keys. The first key is looked up in the context as described above. If it
+is found, the next key is looked up within the previous result. This is
+repeated until a key is not found or until the last key is found. The
+final result is interpolated as above.</p>
+
+<p>Template:</p>
+
+<pre><code>* {{client.name}}
+* {{age}}
+* {{client.company.name}}
+* {{{company.name}}}
+</code></pre>
+
+<p>Hash:</p>
+
+<pre><code>{
+  "client": {
+    "name": "Chris &amp; Friends",
+    "age": 50
+  },
+  "company": {
+    "name": "&lt;b&gt;GitHub&lt;/b&gt;"
+  }
+}
+</code></pre>
+
+<p>Output:</p>
+
+<pre><code>* Chris &amp;amp; Friends
+*
+*
+* &lt;b&gt;GitHub&lt;/b&gt;
+</code></pre>
+
+<p><strong>Implicit Iterator</strong></p>
+
+<p>As a special case, if the <code>name</code> consists of only a dot and nothing else,
+the value that <strong>is</strong> the current context is interpolated as a whole. This
+is especially useful if the parent context is a list; see <strong>Sections</strong>
+below.</p>
+
+<p>Template:</p>
+
+<pre><code>* {{.}}
+</code></pre>
+
+<p>Current context:</p>
+
+<pre><code>"Hello!"
+</code></pre>
+
+<p>Output:</p>
+
+<pre><code>* Hello!
+</code></pre>
+
+<p><strong>Lambdas</strong></p>
+
+<p>If any value found during the lookup is a callable object, such as a
+function or lambda, this object will be invoked with zero arguments. The
+value that is returned is then used instead of the callable object itself.</p>
+
+<p>An <strong>optional</strong> part of the specification states that if the final key in
+the <code>name</code> is a lambda that returns a string, then that string should be
+rendered as a Mustache template before interpolation. It will be rendered
+using the default delimiters (see <strong>Set Delimiter</strong> below) against the
+current context.</p>
+
+<p>Template:</p>
+
+<pre><code>* {{time.hour}}
+* {{today}}
+</code></pre>
+
+<p>Hash:</p>
+
+<pre><code>{
+  "year": 1970,
+  "month": 1,
+  "day": 1,
+  "time": function() {
+    return {
+      "hour": 0,
+      "minute": 0,
+      "second": 0
+    }
+  },
+  "today": function() {
+    return "{{year}}-{{month}}-{{day}}"
+  }
+}
+</code></pre>
+
+<p>Output:</p>
+
+<pre><code>* 0
+* 1970-1-1
+</code></pre>
+
 <h3 id="Sections">Sections</h3>
 
 <p>Sections render blocks of text zero or more times, depending on the
 value of the key in the current context.</p>
 
+<p>Lookup of dotted names works in the same way as with variables, except for
+slightly different treatment of lambdas. More on this below.</p>
+
 <p>A section begins with a pound and ends with a slash. That is,
 <code>{{#person}}</code> begins a "person" section while <code>{{/person}}</code> ends it.</p>
 
-<p>The behavior of the section is determined by the value of the key.</p>
+<p>The behavior of the section is determined by the final value of the key
+lookup.</p>
 
 <p><strong>False Values or Empty Lists</strong></p>
 
@@ -224,34 +334,59 @@ loop over collections.</p>
 
 <p>Output:</p>
 
-<pre><code>&lt;b&gt;resque&lt;/b&gt;
-&lt;b&gt;hub&lt;/b&gt;
-&lt;b&gt;rip&lt;/b&gt;
+<pre><code>  &lt;b&gt;resque&lt;/b&gt;
+  &lt;b&gt;hub&lt;/b&gt;
+  &lt;b&gt;rip&lt;/b&gt;
+</code></pre>
+
+<p>The same effect as above can be obtained without nested objects, by using
+the implicit iterator (see <strong>Variables</strong> above).</p>
+
+<p>Template:</p>
+
+<pre><code>{{#repo}}
+  &lt;b&gt;{{.}}&lt;/b&gt;
+{{/repo}}
+</code></pre>
+
+<p>Hash:</p>
+
+<pre><code>{
+  "repo": ["resque", "hub", "rip"]
+}
+</code></pre>
+
+<p>Output:</p>
+
+<pre><code>  &lt;b&gt;resque&lt;/b&gt;
+  &lt;b&gt;hub&lt;/b&gt;
+  &lt;b&gt;rip&lt;/b&gt;
 </code></pre>
 
 <p><strong>Lambdas</strong></p>
 
-<p>When the value is a callable object, such as a function or lambda, the
-object will be invoked and passed the block of text. The text passed
-is the literal block, unrendered. <code>{{tags}}</code> will not have been expanded
-- the lambda should do that on its own. In this way you can implement
-filters or caching.</p>
+<p>When any value found during the lookup is a callable object, such as a
+function or lambda, the object will be invoked and passed the block of
+text. The text passed is the literal block, unrendered. <code>{{tags}}</code> will
+not have been expanded.</p>
+
+<p>An <strong>optional</strong> part of the specification states that if the final key in
+the <code>name</code> is a lambda that returns a string, then that string replaces
+the content of the section. It will be rendered using the same delimiters
+(see <strong>Set Delimiter</strong> below) as the original section content. In this way
+you can implement filters or caching.</p>
 
 <p>Template:</p>
 
-<pre><code>{{#wrapped}}
-  {{name}} is awesome.
-{{/wrapped}}
+<pre><code>{{#wrapped}}{{name}} is awesome.{{/wrapped}}
 </code></pre>
 
 <p>Hash:</p>
 
 <pre><code>{
   "name": "Willy",
-  "wrapped": function() {
-    return function(text, render) {
-      return "&lt;b&gt;" + render(text) + "&lt;/b&gt;"
-    }
+  "wrapped": function(text) {
+    return "&lt;b&gt;" + text + "&lt;/b&gt;"
   }
 }
 </code></pre>
@@ -282,7 +417,7 @@ context for a single rendering of the block.</p>
 
 <p>Output:</p>
 
-<pre><code>Hi Jon!
+<pre><code>  Hi Jon!
 </code></pre>
 
 <h3 id="Inverted-Sections">Inverted Sections</h3>
@@ -315,7 +450,7 @@ if the key doesn't exist, is false, or is an empty list.</p>
 
 <p>Output:</p>
 
-<pre><code>No repos :(
+<pre><code>  No repos :(
 </code></pre>
 
 <h3 id="Comments">Comments</h3>
@@ -376,6 +511,83 @@ user.mustache:
 {{/names}}
 </code></pre>
 
+<h3 id="Blocks">Blocks</h3>
+
+<p>A block begins with a dollar and ends with a slash. That is, <code>{{$title}}</code>
+begins a "title" block and <code>{{/title}}</code> ends it.</p>
+
+<p>Blocks mark parts of the template that may be overridden. This can be done
+with a block of the same name within a parent section in the calling
+template (see <strong>Parents</strong> below). If not overridden, the contents of a
+block render just as if the <code>{{$title}}</code> and <code>{{/title}}</code> tags weren't
+there.</p>
+
+<p>Blocks could be thought of as template parameters or as inline partials
+that may be passed to another template. They are part of the
+not-yet-official, optional <a href="https://github.com/mustache/spec/pull/75">inheritance specification</a>.</p>
+
+<p>Template <code>article.mustache</code>:</p>
+
+<pre><code>&lt;h1&gt;{{$title}}The News of Today{{/title}}&lt;/h1&gt;
+{{$body}}
+&lt;p&gt;Nothing special happened.&lt;/p&gt;
+{{/body}}
+</code></pre>
+
+<p>Output:</p>
+
+<pre><code>&lt;h1&gt;The News of Today&lt;/h1&gt;
+&lt;p&gt;Nothing special happened.&lt;/p&gt;
+</code></pre>
+
+<h3 id="Parents">Parents</h3>
+
+<p>A parent begins with a less than sign and ends with a slash. That is,
+<code>{{&lt;article}}</code> begins an "article" parent and <code>{{/article}}</code> ends it.</p>
+
+<p>Like an <code>{{&gt;article}}</code> partial, a parent lets you expand another template
+inside the current one. Unlike a partial, a parent also lets you override
+blocks of the other template.</p>
+
+<p>Blocks within a parent can again be overridden by another including
+template. Other content within a parent is ignored, like comments.</p>
+
+<p>Template:</p>
+
+<pre><code>{{&lt;article}}
+  Never shown
+  {{$body}}
+    {{#headlines}}
+    &lt;p>{{.}}&lt;/p&gt;
+    {{/headlines}}
+  {{/body}}
+{{/article}}
+
+{{&lt;article}}
+  {{$title}}Yesterday{{/title}}
+{{/article}}
+</code></pre>
+
+<p>Hash:</p>
+
+<pre><code>{
+  "headlines": [
+    "A pug's handler grew mustaches.",
+    "What an exciting day!"
+  ]
+}
+</code></pre>
+
+<p>Output, assuming the <code>article.mustache</code> from before:</p>
+
+<pre><code>&lt;h1&gt;The News of Today&lt;/h1&gt;
+&lt;p&gt;A pug's handler grew mustaches.&lt;/p&gt;
+&lt;p&gt;What an exciting day!&lt;/p&gt;
+
+&lt;h1&gt;Yesterday&lt;/h1&gt;
+&lt;p&gt;Nothing special happened.&lt;/p&gt;
+</code></pre>
+
 <h3 id="Set-Delimiter">Set Delimiter</h3>
 
 <p>Set Delimiter tags start with an equal sign and change the tag
@@ -395,7 +607,7 @@ tag style, the second uses erb style as defined by the Set Delimiter
 tag, and the third returns to the default style after yet another Set
 Delimiter declaration.</p>
 
-<p>According to <a href="http://google-ctemplate.googlecode.com/svn/trunk/doc/howto.html">ctemplates</a>, this "is useful for languages like TeX, where
+<p>According to <a href="http://goog-ctemplate.sourceforge.net/doc/howto.html">ctemplates</a>, this "is useful for languages like TeX, where
 double-braces may occur in the text and are awkward to use for
 markup."</p>
 
@@ -409,13 +621,13 @@ markup."</p>
 
 <h2 id="SEE-ALSO">SEE ALSO</h2>
 
-<p><a class="man-ref" href="mustache.1.ronn.html">mustache<span class="s">(1)</span></a>,
+<p><a class="man-ref" href="mustache.1.ron.html">mustache<span class="s">(1)</span></a>,
 <a href="http://mustache.github.io/" data-bare-link="true">http://mustache.github.io/</a></p>
 
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'>DEFUNKT</li>
-    <li class='tc'>November 2016</li>
+    <li class='tc'>April 2021</li>
     <li class='tr'>mustache(5)</li>
   </ol>
 

--- a/man/mustache.5.ron
+++ b/man/mustache.5.ron
@@ -38,6 +38,13 @@ clauses, or for loops. Instead there are only tags. Some tags are
 replaced with a value, some nothing, and others a series of
 values. This document explains the different types of Mustache tags.
 
+The Mustache language has a [formal specification][spec]. The current manpage
+reflects version 1.1.3 of the specification, as well as the de facto
+established [candidate extension for template inheritance][inheritance].
+
+[spec]: https://github.com/mustache/spec
+[inheritance]: https://github.com/mustache/spec/pull/75
+
 
 ## TAG TYPES
 
@@ -85,16 +92,113 @@ Output:
     * &lt;b&gt;GitHub&lt;/b&gt;
     * <b>GitHub</b>
 
+**Dotted Names**
+
+If the `name` contains dots, it is split on the dots to obtain multiple
+keys. The first key is looked up in the context as described above. If it
+is found, the next key is looked up within the previous result. This is
+repeated until a key is not found or until the last key is found. The
+final result is interpolated as above.
+
+Template:
+
+    * {{client.name}}
+    * {{age}}
+    * {{client.company.name}}
+    * {{{company.name}}}
+
+Hash:
+
+    {
+      "client": {
+        "name": "Chris & Friends",
+        "age": 50
+      },
+      "company": {
+        "name": "<b>GitHub</b>"
+      }
+    }
+
+Output:
+
+    * Chris &amp; Friends
+    *
+    *
+    * <b>GitHub</b>
+
+**Implicit Iterator**
+
+As a special case, if the `name` consists of only a dot and nothing else,
+the value that **is** the current context is interpolated as a whole. This
+is especially useful if the parent context is a list; see **Sections**
+below.
+
+Template:
+
+    * {{.}}
+
+Current context:
+
+    "Hello!"
+
+Output:
+
+    * Hello!
+
+**Lambdas**
+
+If any value found during the lookup is a callable object, such as a
+function or lambda, this object will be invoked with zero arguments. The
+value that is returned is then used instead of the callable object itself.
+
+An **optional** part of the specification states that if the final key in
+the `name` is a lambda that returns a string, then that string should be
+rendered as a Mustache template before interpolation. It will be rendered
+using the default delimiters (see **Set Delimiter** below) against the
+current context.
+
+Template:
+
+    * {{time.hour}}
+    * {{today}}
+
+Hash:
+
+    {
+      "year": 1970,
+      "month": 1,
+      "day": 1,
+      "time": function() {
+        return {
+          "hour": 0,
+          "minute": 0,
+          "second": 0
+        }
+      },
+      "today": function() {
+        return "{{year}}-{{month}}-{{day}}"
+      }
+    }
+
+Output:
+
+    * 0
+    * 1970-1-1
+
 
 ### Sections
 
 Sections render blocks of text zero or more times, depending on the
 value of the key in the current context.
 
+Lookup of dotted names works in the same way as with variables, except for
+slightly different treatment of lambdas. More on this below.
+
 A section begins with a pound and ends with a slash. That is,
 `{{#person}}` begins a "person" section while `{{/person}}` ends it.
 
-The behavior of the section is determined by the value of the key.
+The behavior of the section is determined by the final value of the key
+lookup.
 
 **False Values or Empty Lists**
 
@@ -146,32 +250,54 @@ Hash:
 
 Output:
 
-    <b>resque</b>
-    <b>hub</b>
-    <b>rip</b>
+      <b>resque</b>
+      <b>hub</b>
+      <b>rip</b>
 
-**Lambdas**
-
-When the value is a callable object, such as a function or lambda, the
-object will be invoked and passed the block of text. The text passed
-is the literal block, unrendered. `{{tags}}` will not have been expanded
-- the lambda should do that on its own. In this way you can implement
-filters or caching.
+The same effect as above can be obtained without nested objects, by using
+the implicit iterator (see **Variables** above).
 
 Template:
 
-    {{#wrapped}}
-      {{name}} is awesome.
-    {{/wrapped}}
+    {{#repo}}
+      <b>{{.}}</b>
+    {{/repo}}
+
+Hash:
+
+    {
+      "repo": ["resque", "hub", "rip"]
+    }
+
+Output:
+
+      <b>resque</b>
+      <b>hub</b>
+      <b>rip</b>
+
+**Lambdas**
+
+When any value found during the lookup is a callable object, such as a
+function or lambda, the object will be invoked and passed the block of
+text. The text passed is the literal block, unrendered. `{{tags}}` will
+not have been expanded.
+
+An **optional** part of the specification states that if the final key in
+the `name` is a lambda that returns a string, then that string replaces
+the content of the section. It will be rendered using the same delimiters
+(see **Set Delimiter** below) as the original section content. In this way
+you can implement filters or caching.
+
+Template:
+
+    {{#wrapped}}{{name}} is awesome.{{/wrapped}}
 
 Hash:
 
     {
       "name": "Willy",
-      "wrapped": function() {
-        return function(text, render) {
-          return "<b>" + render(text) + "</b>"
-        }
+      "wrapped": function(text) {
+        return "<b>" + text + "</b>"
       }
     }
 
@@ -198,7 +324,7 @@ Hash:
 
 Output:
 
-    Hi Jon!
+      Hi Jon!
 
 
 ### Inverted Sections
@@ -229,7 +355,7 @@ Hash:
 
 Output:
 
-    No repos :(
+      No repos :(
 
 
 ### Comments
@@ -284,6 +410,80 @@ Can be thought of as a single, expanded template:
     {{#names}}
       <strong>{{name}}</strong>
     {{/names}}
+
+
+### Blocks
+
+A block begins with a dollar and ends with a slash. That is, `{{$title}}`
+begins a "title" block and `{{/title}}` ends it.
+
+Blocks mark parts of the template that may be overridden. This can be done
+with a block of the same name within a parent section in the calling
+template (see **Parents** below). If not overridden, the contents of a
+block render just as if the `{{$title}}` and `{{/title}}` tags weren't
+there.
+
+Blocks could be thought of as template parameters or as inline partials
+that may be passed to another template. They are part of the
+not-yet-official, optional [inheritance specification][inheritance].
+
+Template `article.mustache`:
+
+    <h1>{{$title}}The News of Today{{/title}}</h1>
+    {{$body}}
+    <p>Nothing special happened.</p>
+    {{/body}}
+
+Output:
+
+    <h1>The News of Today</h1>
+    <p>Nothing special happened.</p>
+
+
+### Parents
+
+A parent begins with a less than sign and ends with a slash. That is,
+`{{<article}}` begins an "article" parent and `{{/article}}` ends it.
+
+Like an `{{>article}}` partial, a parent lets you expand another template
+inside the current one. Unlike a partial, a parent also lets you override
+blocks of the other template.
+
+Blocks within a parent can again be overridden by another including
+template. Other content within a parent is ignored, like comments.
+
+Template:
+
+    {{<article}}
+      Never shown
+      {{$body}}
+        {{#headlines}}
+        <p>{{.}}</p>
+        {{/headlines}}
+      {{/body}}
+    {{/article}}
+
+    {{<article}}
+      {{$title}}Yesterday{{/title}}
+    {{/article}}
+
+Hash:
+
+    {
+      "headlines": [
+        "A pug's handler grew mustaches.",
+        "What an exciting day!"
+      ]
+    }
+
+Output, assuming the `article.mustache` from before:
+
+    <h1>The News of Today</h1>
+    <p>A pug's handler grew mustaches.</p>
+    <p>What an exciting day!</p>
+
+    <h1>Yesterday</h1>
+    <p>Nothing special happened.</p>
 
 
 ### Set Delimiter

--- a/man/mustache.5.ron
+++ b/man/mustache.5.ron
@@ -39,7 +39,7 @@ replaced with a value, some nothing, and others a series of
 values. This document explains the different types of Mustache tags.
 
 The Mustache language has a [formal specification][spec]. The current
-manpage reflects version 1.2.1 of the specification, including the
+manpage reflects version 1.3.0 of the specification, including the
 official-but-optional extensions for lambdas and inheritance.
 
 [spec]: https://github.com/mustache/spec
@@ -411,6 +411,36 @@ Can be thought of as a single, expanded template:
     {{/names}}
 
 
+**Dynamic Names**
+
+Partials can be loaded dynamically at runtime using Dynamic Names; an
+**optional** part of the Mustache specification which allows to dynamically
+determine a tag's content at runtime.
+
+Dynamic Names consists of an asterisk, followed by a dotted name which follows
+the same notation and the same resolution as in an variable tag. That is
+`{{>*dynamic}}`. It can be thought as the following **hypothetical** tag
+(which is **not allowed**!): `{{>{{dynamic}}}}`.
+
+Templates:
+
+    main.mustache:
+    Hello {{>*dynamic}}
+    
+    world.template:
+    everyone!
+
+Hash:
+
+    {
+      "dynamic": "world"
+    }
+
+Output:
+
+    Hello everyone!
+
+
 ### Blocks
 
 A block begins with a dollar and ends with a slash. That is, `{{$title}}`
@@ -483,6 +513,35 @@ Output, assuming the `article.mustache` from before:
 
     <h1>Yesterday</h1>
     <p>Nothing special happened.</p>
+
+**Dynamic Names**
+
+Some mustache implementations may allow the use of Dynamic Names in
+parent tags, similar to dynamic names in partials. Here's an example of
+how Dynamic Names in parent tags work.
+
+Templates:
+
+    {{!normal.mustache}}
+    {{$text}}Here goes nothing.{{/text}}
+
+    {{!bold.mustache}}
+    <b>{{$text}}Here also goes nothing but it's bold.{{/text}}</b>
+
+    {{!dynamic.mustache}}
+    {{<*dynamic}}
+      {{$text}}Hello World!{{/text}}
+    {{/*dynamic}}
+
+Hash:
+
+    {
+      "dynamic": "bold"
+    }
+
+Output:
+
+    <b>Hello World!</b>
 
 
 ### Set Delimiter

--- a/man/mustache.5.ron
+++ b/man/mustache.5.ron
@@ -128,7 +128,7 @@ Output:
 **Implicit Iterator**
 
 As a special case, if the `name` consists of only a dot and nothing else,
-the value that **is** the current context is interpolated as a whole. This
+the value that is the current context is interpolated as a whole. This
 is especially useful if the parent context is a list; see **Sections**
 below.
 

--- a/man/mustache.5.ron
+++ b/man/mustache.5.ron
@@ -38,12 +38,11 @@ clauses, or for loops. Instead there are only tags. Some tags are
 replaced with a value, some nothing, and others a series of
 values. This document explains the different types of Mustache tags.
 
-The Mustache language has a [formal specification][spec]. The current manpage
-reflects version 1.1.3 of the specification, as well as the de facto
-established [candidate extension for template inheritance][inheritance].
+The Mustache language has a [formal specification][spec]. The current
+manpage reflects version 1.2.1 of the specification, including the
+official-but-optional extensions for lambdas and inheritance.
 
 [spec]: https://github.com/mustache/spec
-[inheritance]: https://github.com/mustache/spec/pull/75
 
 
 ## TAG TYPES
@@ -424,8 +423,8 @@ block render just as if the `{{$title}}` and `{{/title}}` tags weren't
 there.
 
 Blocks could be thought of as template parameters or as inline partials
-that may be passed to another template. They are part of the
-not-yet-official, optional [inheritance specification][inheritance].
+that may be passed to another template. They are part of the optional
+inheritance extension.
 
 Template `article.mustache`:
 


### PR DESCRIPTION
These changes aim to make the manpage an accurate, implementation-agnostic overview of the Mustache language again. In a nutshell, I made the following additions and changes:

- Mention of the specification in the DESCRIPTION section.
- Mention of dotted names, implicit iterators and lambdas in the Variables section, with a distinction between required and optional lambda behavior.
- Acknowledgement of dotted names in the Sections section.
- Example of implicit iterator in the Sections Non-Empty Lists section.
- Distinction between required and optional lambda behavior in the Sections Lamdbas section.
- Whitespace changes in several example templates and outputs to more accurately reflect what the specification dictates.
- Replaced the Ruby-inspired double callback contruction of the `wrapped` function in the Sections Lambdas section by a direct pseudomethod. The previous notation led to misunderstandings, especially when it was taken too literally when porting it to other languages such as [JavaScript](https://github.com/janl/mustache.js/#functions).
- Removed the second `render` argument of the `wrapped` lambda in order to reflect the spec.
- Added Blocks and Parents sections in order to document the inheritance candidate extension (mustache/spec#125).

The outdated content of the manpage came up in the discussion of mustache/spec#125; these are essentially parallel PRs with the common aim of refreshing the Mustache documentation. Discussion and changes in either PR could potentially influence the other PR. In particular, if mustache/spec#125 is merged first, some wording with regard to the "candidate" status of the inheritance spec may need to be revised in the current PR.

I should mention that running `rake man` proved challenging. I needed to make a couple of edits in the gemspec and the Rakefile order to make it work, and it still produced error messages although the generated html and roff files did seem to update correctly. I can share those edits if desired.

*Edit to add: given the lack of response from those authorized to merge this PR, I have decided to host my own copy of the updated manual for the time being. Jump to [this comment](https://github.com/mustache/mustache/pull/266#issuecomment-1014986964) for details.*