### PR TITLE
feat(parser): add @ to the list of allowed contents in a tag name

### DIFF
--- a/lib/mustache/parser.rb
+++ b/lib/mustache/parser.rb
@@ -78,7 +78,7 @@ EOF
     SKIP_WHITESPACE = [ '#', '^', '/', '<', '>', '=', '!' ].map(&:freeze)
 
     # The content allowed in a tag name.
-    ALLOWED_CONTENT = /(\w|[?!\/.-])*/
+    ALLOWED_CONTENT = /(\w|[?!\/.-@])*/
 
     # These types of tags allow any content,
     # the rest only allow ALLOWED_CONTENT.


### PR DESCRIPTION
Related to the old issue https://github.com/mustache/mustache/issues/216.

The @ is actually allowed in many other Mustache implementations, so it seemed appropriate to add it.