### PR TITLE
typo: mustache.github.com → .io + HTTPS

### DIFF
--- a/bin/mustache
+++ b/bin/mustache
@@ -23,7 +23,7 @@ class Mustache
         opts.separator " "
 
         opts.separator "  See mustache(1) or " +
-          "http://mustache.github.com/mustache.1.html"
+          "https://mustache.github.io/mustache.1.html"
         opts.separator "  for more details."
 
         opts.separator " "


### PR DESCRIPTION
mustache.github.com is invalid (HTTP 404).
github.io hosts GitHub Pages, and is the correct place.

As http redirects to https anyway, default to it.
WIth 64 chars it fits within 80 col.

***

https://github.com/mustache/mustache.github.com should in theory be also renamed to .io