### PR TITLE
Mark mutable strings as mutable

### DIFF
--- a/lib/mustache/generator.rb
+++ b/lib/mustache/generator.rb
@@ -88,7 +88,7 @@ class Mustache
     def compile!(exp)
       case exp.first
       when :multi
-        exp[1..-1].reduce("") { |sum, e| sum << compile!(e) }
+        exp[1..-1].reduce(+"") { |sum, e| sum << compile!(e) }
       when :static
         str(exp[1])
       when :mustache

--- a/lib/mustache/utils.rb
+++ b/lib/mustache/utils.rb
@@ -22,7 +22,7 @@ class Mustache
           .split('::')
           .map do |part|
             part[0] = part[0].downcase
-            part.gsub(/[A-Z]/) { |s| "_" << s.downcase }
+            part.gsub(/[A-Z]/) { |s| +"_" << s.downcase }
           end
           .join('/')
       end


### PR DESCRIPTION
This updated mustache to work with,

RUBYOPT="--enable-frozen-string-literal" which will be default in future Ruby versions