### PR TITLE
Add magic frozen_string_literal: false comments to source files

### DIFF
--- a/lib/mustache.rb
+++ b/lib/mustache.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: false
 require 'mustache/enumerable'
 require 'mustache/template'
 require 'mustache/context'

--- a/lib/mustache/context.rb
+++ b/lib/mustache/context.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: false
 require 'mustache/context_miss'
 
 class Mustache

--- a/lib/mustache/context_miss.rb
+++ b/lib/mustache/context_miss.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: false
 class Mustache
 
   # A ContextMiss is raised whenever a tag's target can not be found

--- a/lib/mustache/enumerable.rb
+++ b/lib/mustache/enumerable.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: false
 class Mustache
   Enumerable = Module.new
 end

--- a/lib/mustache/generator.rb
+++ b/lib/mustache/generator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: false
 class Mustache
   # The Generator is in charge of taking an array of Mustache tokens,
   # usually assembled by the Parser, and generating an interpolatable

--- a/lib/mustache/parser.rb
+++ b/lib/mustache/parser.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: false
 require 'strscan'
 
 class Mustache

--- a/lib/mustache/settings.rb
+++ b/lib/mustache/settings.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: false
 # Settings which can be configured for all view classes, a single
 # view class, or a single Mustache instance.
 class Mustache

--- a/lib/mustache/template.rb
+++ b/lib/mustache/template.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: false
 require 'cgi'
 
 require 'mustache/parser'

--- a/lib/mustache/utils.rb
+++ b/lib/mustache/utils.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: false
 class Mustache
   module Utils
     class String

--- a/lib/mustache/version.rb
+++ b/lib/mustache/version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: false
 class Mustache
   VERSION = '1.1.1'
 end


### PR DESCRIPTION
In order to make the code not emit warnings with ruby 3.4.x and compatible with 3.5.x magic frozen_string_literal: false comments are added to the source files.

In the future the code could be audited and changed to be compatible with frozen string literals. A known incompatible line is in lib/generator.rb:

```ruby
        exp[1..-1].reduce("") { |sum, e| sum << compile!(e) }
```

See: https://bugs.ruby-lang.org/issues/20205

> Workflow for library maintainers
> As a library maintainer, fixing the deprecation warnings can be as simple as prepending # frozen_string_literal: false at the top of all their source files, and this will keep working forever.
>
> Alternatively they can of course make their code compatible with frozen string literals.
>
> Code that is frozen string literal compatible doesn't need to explicitly declare it. Only code that need it turned of need to do so.