### PR TITLE
Use `cgi/escape` instead of `cgi`

### DIFF
--- a/lib/mustache/template.rb
+++ b/lib/mustache/template.rb
@@ -1,4 +1,8 @@
-require 'cgi'
+begin
+  require 'cgi/escape'
+rescue LoadError
+  require 'cgi/util'
+end
 
 require 'mustache/parser'
 require 'mustache/generator'


### PR DESCRIPTION
### Background
A warning is currently emitted in CI when running with ruby 4.0.
This warning occurs because retire CGI library from Ruby 4.0.

- https://bugs.ruby-lang.org/issues/21258

```sh
$ bundle exec rake 
/home/runner/work/mustache/mustache/lib/mustache/template.rb:1: warning: CGI library is removed from Ruby 4.0. Please use cgi/escape instead for CGI.escape and CGI.unescape features.
If you need to use the full features of CGI library, Please install cgi gem.
```
https://github.com/mustache/mustache/actions/runs/22350950048/job/64677636272#step:4:6

### Details
This Pull Request fixes the warning by replacing the use of `cgi` with `cgi/escape`.
The `cgi/escape` is available since Ruby 2.3.

For compatibility with Ruby versions earlier than 2.3, this change ensures that if requiring `cgi/escape` raises a LoadError, it falls back to requiring `cgi/util`.
